### PR TITLE
alttech: Temporarily unpublish Parler.

### DIFF
--- a/website/content/alttech/parler/index.md
+++ b/website/content/alttech/parler/index.md
@@ -20,6 +20,7 @@ legal:
     wc: 1556
     asof: 2020-07-01
 weight: 2
+draft: true
 ---
 
 Parler (which means "to speak" in French) is a social networking and


### PR DESCRIPTION
Parler seems to be taking questionable actions during this recent spike in popularity.
* https://news.avclub.com/parler-the-free-speech-alternative-to-twitter-keeps-1844238633
* https://www.techdirt.com/articles/20200625/16303844790/just-like-every-other-platform-parler-will-take-down-content-face-impossible-content-moderation-choices.shtml

This shouldn't be happening at all, but I'm starting to see a bigger and bigger gap between Parler and something like Minds, and less of one between Parler and Gab.

Until this stuff gets sorted out, it should be unpublished so it's not suggested as a viable alternative.