### PR TITLE
refactor: Create a data partial for all event pages.

### DIFF
--- a/website/layouts/partials/data/events.html
+++ b/website/layouts/partials/data/events.html
@@ -1,0 +1,2 @@
+{{ $events := (.Site.GetPage "/events").Pages }}
+{{ return $events }}

--- a/website/layouts/platforms/single.html
+++ b/website/layouts/platforms/single.html
@@ -8,7 +8,7 @@
 	{{ $alts := (.Site.GetPage "/alttech").Pages }}
 	{{ $alts := where $alts "Params.altfor" "intersect" (slice $name) }}
 
-	{{ $events := (.Site.GetPage "/events").Pages }}
+	{{ $events := partialCached "data/events" . }}
 	{{ $events := where $events "Params.platforms" "intersect" (slice $name) }}
 
 	{{ $sumsData := partialCached "data/platform-sums.html" . }}


### PR DESCRIPTION
The purpose here is better engineering, not any wrongly perceived performance gains. There should be one way to "get all the event pages" so that if this methodology for some reason changes, the refactoring takes place in one spot.

The bonus is improved readability.