### PR TITLE
refactor: Don't render unused attributes in icon partial.

### DIFF
--- a/website/assets/css/cards.css
+++ b/website/assets/css/cards.css
@@ -80,6 +80,8 @@ a.card:hover:after {
 }
 .event.card header .icon {
 	margin-right: 0.5rem;
+	width: 20px;
+	height: 20px;
 }
 
 .profile.card {

--- a/website/layouts/partials/cards/event.html
+++ b/website/layouts/partials/cards/event.html
@@ -1,4 +1,4 @@
-{{ $eventIcon := partialCached "icon" (dict "name" "event" "size" 20) "event-card-event" }}
+{{ $eventIcon := partialCached "icon" (dict "name" "event" "size" "") "event-card-event" }}
 
 {{ $date := .Date.Format "Jan 2, 2006" }}
 {{ $preview := .Params.preview | default .Summary | truncate 90 }}

--- a/website/layouts/partials/event-profiles.html
+++ b/website/layouts/partials/event-profiles.html
@@ -1,5 +1,5 @@
-{{ $toggleIcon := partialCached "icon.html" "people" "people" }}
-{{ $headerIcon := partialCached "icon.html" (dict "name" "account_box" "size" 40) "event-profiles-header" }}
+{{ $toggleIcon := partialCached "icon" (dict "name" "people" "color" "#fff") "event-profiles-toggle" }}
+{{ $headerIcon := partialCached "icon" (dict "name" "account_box" "size" 40) "event-profiles-header" }}
 
 <input type="checkbox" class="toggle" id="profileDrawerToggle">
 

--- a/website/layouts/partials/icon.html
+++ b/website/layouts/partials/icon.html
@@ -3,7 +3,7 @@
 {{ $color := "" }}
 {{ $size := 24 }}
 
-<!-- If the context is a map, use its values instead. -->
+<!-- If the context is a map, process its values. -->
 {{ if reflect.IsMap . }}
 	{{ $name = .name | default "lens" }}
 	{{ $color = .color | default $color }}

--- a/website/layouts/partials/icon.html
+++ b/website/layouts/partials/icon.html
@@ -1,17 +1,17 @@
 <!-- Default values for color, size and name. -->
-{{ $color := "#fff" }}
-{{ $size := 24 }}
 {{ $name := . }}
+{{ $color := "" }}
+{{ $size := 24 }}
 
-<!-- If the context is a map, use it's values instead (if they're set). -->
+<!-- If the context is a map, use its values instead. -->
 {{ if reflect.IsMap . }}
-	{{ $color = default $color .color }}
-	{{ $size = default $size .size }}
-	{{ $name = default "lens" .name }}
+	{{ $name = .name | default "lens" }}
+	{{ $color = .color | default $color }}
+	{{ if isset . "size" }} {{ $size = .size }} {{ end }}
 {{ end }}
 
 <div class="icon">
-	<svg width="{{ $size }}" height="{{ $size }}" viewBox="0 0 24 24" fill="{{ $color }}">
+	<svg viewBox="0 0 24 24" fill="{{ $color }}" width="{{ $size }}" height="{{ $size }}">
 		{{ index site.Data.icons $name | safeHTML }}
 	</svg>
 </div>


### PR DESCRIPTION
This PR prevents the icon partial from rendering attributes that get overridden in CSS anyway. On the events page _alone_, this saves 5400 characters worth of text. That's not to mention this way is more inline with how the project is structured to begin with.

It is now assumed that the icon's color will be set in CSS unless a color is provided to the partial.