### PR TITLE
refactor: Use stylesheet for event page CSS instead of inlining it.

### DIFF
--- a/website/layouts/events/single.html
+++ b/website/layouts/events/single.html
@@ -1,5 +1,5 @@
 {{ define "style" }}
-	{{ partialCached "css-inline.html" "pages/events.css" "events" }}
+	{{ partialCached "css-events.html" . }}
 {{ end }}
 
 {{ define "main" }}

--- a/website/layouts/partials/css-events.html
+++ b/website/layouts/partials/css-events.html
@@ -1,0 +1,3 @@
+{{ $css := resources.Get "css/pages/events.css" | minify | fingerprint "sha512" }}
+
+<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">


### PR DESCRIPTION
This should cause slightly slower initial requests but slightly quicker subsequent requests because the browser will already have all that CSS (only `1.8kb` right now). In other words, the size of each event page is reduced by `1.8kb`, and the Hugo build time is slightly improved as well since all that styling isn't rendered for each event page.