### PR TITLE
refactor: Change 'preview' to 'summary' in event frontmatters.

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -2,6 +2,7 @@ languageCode = "en-us"
 disableKinds = [ "RSS" ]
 title = "BigTech.fail"
 enableEmoji = true
+summaryLength = 25
 
 [frontmatter]
 	lastmod = [ ":git", "lastmod" ]

--- a/website/content/events/apple-removes-hkmap-live-app/index.md
+++ b/website/content/events/apple-removes-hkmap-live-app/index.md
@@ -1,9 +1,8 @@
 ---
 date: 2019-10-09
-order: 1
 title: Apple Removes HKmap.live From App Store
 image: /img/logos/hkmap-live.jpg
-preview: ...the day after Apple was criticized by the Chinese Communist Party's news outlet
+summary: ...the day after Apple was criticized by the Chinese Communist Party's news outlet
 platforms: [ apple ]
 tags: [ content-removed ]
 sources:

--- a/website/content/events/apple-removes-taiwan-flag-emoji-for-hong-kong-and-macau-users/index.md
+++ b/website/content/events/apple-removes-taiwan-flag-emoji-for-hong-kong-and-macau-users/index.md
@@ -2,7 +2,6 @@
 date: 2019-10-03
 title: Apple Removes Taiwan Flag Emoji For Hong Kong and Macau Users
 image: /img/misc/taiwan-flag-emoji.png
-preview: Amid the very heated, pro-democracy protests in Hong Kong
 platforms: [ apple ]
 tags: [ content-removed ]
 sources:
@@ -18,7 +17,7 @@ sources:
  - [ 'Quartz "You can’t use the Taiwan flag emoji on a Chinese iPhone" by Josh Horwitz', 'https://qz.com/1250884/you-cant-use-the-taiwan-flag-emoji-on-a-chinese-iphone/' ]
 ---
 
-This ~~sneaky~~ move by Apple seems to have been discovered in the very beginning of October by a software developer.
+This sneaky move by Apple seems to have been discovered in the very beginning of October by a software developer.
 (It was picked up by independent media a few days later.)
 
 [A Hiraku Dev blog post](https://hiraku.tw/2019/10/4877/) details the difference in the section source code, betweeon iOS 13.0 and iOS 13.1.1, that controls whether the flag will be displayed or not.

--- a/website/content/events/apple-removes-vpn-apps-from-china-app-store/index.md
+++ b/website/content/events/apple-removes-vpn-apps-from-china-app-store/index.md
@@ -2,7 +2,7 @@
 date: 2017-07-29
 title: Apple Removes VPN Apps From China App Store
 image: /img/misc/chipple.png
-preview: To say this isn't a good look for Apple would be a bit of an understatement
+summary: To say this isn't a good look for Apple would be a bit of an understatement
 platforms: [ apple ]
 tags: [ content-removed ]
 sources:

--- a/website/content/events/apple-shuts-down-ibooks-and-itunes-movies-in-china/index.md
+++ b/website/content/events/apple-shuts-down-ibooks-and-itunes-movies-in-china/index.md
@@ -2,7 +2,7 @@
 date: 2016-04-21
 title: Apple Shuts Down iBooks and iTunes Movies Apps In China
 image: /img/misc/chipple.png
-preview: So apparently, they'll even remove their own apps lol
+summary: So apparently, they'll even remove their own apps lol
 platforms: [ apple ]
 tags: [ content-removed ]
 sources:

--- a/website/content/events/facebook-suspends-tim-pool/index.md
+++ b/website/content/events/facebook-suspends-tim-pool/index.md
@@ -1,9 +1,7 @@
 ---
 date: 2019-11-10
-order: 1
 title: Facebook Suspends Tim Pool For Reporting On Alleged CIA Whistleblower
 image: /img/people/tim-pool.jpg
-preview: "All for saying the words \"Eric Ciaramella\" in a post linking to POLITICO"
 profiles: [ tim-pool ]
 platforms: [ facebook ]
 tags: [ suspended ]

--- a/website/content/events/facebook-youtube-purge-mentions-of-eric-ciaramella-as-alleged-whistleblower/index.md
+++ b/website/content/events/facebook-youtube-purge-mentions-of-eric-ciaramella-as-alleged-whistleblower/index.md
@@ -2,7 +2,7 @@
 date: 2019-11-07
 title: Facebook and YouTube Purge Any Mention of Eric Ciaramella As Alleged Whistleblower
 image: /img/misc/ciar.jpg
-preview: ...basically confirming that he is in fact the alleged whistleblower, right?
+summary: ...basically confirming that he is in fact the alleged whistleblower, right?
 platforms: [ facebook, youtube ]
 tags: [ content-removed ]
 sources:

--- a/website/content/events/google-bans-gab-from-play-store-again/index.md
+++ b/website/content/events/google-bans-gab-from-play-store-again/index.md
@@ -2,7 +2,7 @@
 date: 2019-07-19
 title: Google Bans Gab From the Play Store, Again
 image: /img/misc/gab-ai-banned.png
-preview: But this time, it's even worse...
+summary: But this time, it's even worse...
 platforms: [ google ]
 tags: [ banned, content-removed ]
 sources:

--- a/website/content/events/james-woods-quits-twitter/index.md
+++ b/website/content/events/james-woods-quits-twitter/index.md
@@ -2,7 +2,6 @@
 date: 2019-05-09
 title: James Woods Quits Twitter
 image: /img/people/james-woods.jpg
-preview: A few weeks after Twitter suspended actor James Woods for the 2nd time
 platforms: [ twitter ]
 tags: [ walked-away ]
 sources:

--- a/website/content/events/matt-christiansen-has-call-with-patreon/index.md
+++ b/website/content/events/matt-christiansen-has-call-with-patreon/index.md
@@ -3,7 +3,7 @@ date: 2018-12-20
 order: 2
 title: Matt Christiansen Further Exposes Patreon In Call With Jacqueline Hart
 image: /img/people/matt-christiansen.jpg
-preview: In this phone call, Matt gives Patreon more than enough rope to metaphorically hang themselves
+summary: In this phone call, Matt gives Patreon more than enough rope to metaphorically hang themselves
 profiles: [ matt-christiansen ]
 platforms: [ patreon ]
 sources:

--- a/website/content/events/patreon-bans-bitchute/index.md
+++ b/website/content/events/patreon-bans-bitchute/index.md
@@ -2,7 +2,6 @@
 date: 2018-11-29
 title: Patreon Bans BitChute
 image: /img/logos/bitchute.png
-preview: About two weeks after being banned from Paypal, BitChute was banned from Patreon as well.
 platforms: [ patreon ]
 tags: [ banned, defunded ]
 sources:

--- a/website/content/events/patreon-bans-mister-metokur/index.md
+++ b/website/content/events/patreon-bans-mister-metokur/index.md
@@ -2,7 +2,7 @@
 date: 2019-11-21
 title: Patreon Bans Mister Metokur For Showing Footage of Trans Surgeries
 image: /img/people/mister-metokur.jpg
-preview: And Patreon classified that as "hate speech." Let that sink in
+summary: And Patreon classified that as "hate speech." Let that sink in
 platforms: [ patreon ]
 tags: [ banned, defunded ]
 sources:

--- a/website/content/events/patreon-bans-robert-spencer/index.md
+++ b/website/content/events/patreon-bans-robert-spencer/index.md
@@ -1,9 +1,8 @@
 ---
 date: 2018-08-14
-order: 1
 title: Patreon Bans Robert Spencer
 image: /img/people/robert-spencer.jpg
-preview: Turns out Patreon is actually Mastercard's bitch, believe it or not
+summary: Turns out Patreon is actually Mastercard's bitch, believe it or not
 platforms: [ patreon ]
 tags: [ banned, defunded ]
 sources:

--- a/website/content/events/patreon-bans-soph/index.md
+++ b/website/content/events/patreon-bans-soph/index.md
@@ -2,7 +2,7 @@
 date: 2019-08-02
 title: Patreon Bans Soph the Day After She's Banned From YouTube
 image: /img/people/soph.jpg
-preview: BigTech scared of a 14 year old girl lol
+summary: BigTech scared of a 14 year old girl lol
 platforms: [ patreon ]
 tags: [ banned ]
 sources:

--- a/website/content/events/pinterest-bans-live-action/index.md
+++ b/website/content/events/pinterest-bans-live-action/index.md
@@ -1,9 +1,8 @@
 ---
 date: 2019-06-11
-order: 2
 title: Pinterest Bans LiveAction
 image: /img/logos/live-action.jpg
-preview: ...right as it's revealed that Pinterest shadow bans their content
+summary: ...right as it's revealed that Pinterest shadow bans their content
 platforms: [ pinterest ]
 tags: [ banned ]
 sources:

--- a/website/content/events/reddit-quarantines-the-donald-subreddit/index.md
+++ b/website/content/events/reddit-quarantines-the-donald-subreddit/index.md
@@ -2,7 +2,6 @@
 date: 2019-06-26
 title: Reddit Quarantines r/The_Donald
 image: /img/logos/reddit-the-donald.png
-preview: So only politicians can openly threaten violence without consequence? Gotcha
 platforms: [ reddit ]
 tags: [ quarantine ]
 sources:

--- a/website/content/events/spotify-partners-with-splc-adl-to-police-hate/index.md
+++ b/website/content/events/spotify-partners-with-splc-adl-to-police-hate/index.md
@@ -2,7 +2,7 @@
 date: 2018-05-10
 title: Spotify Partners With the SPLC and ADL to Police Hate Content
 image: /img/logos/spotify.png
-preview: What could possibly go wrong
+summary: What could possibly go wrong
 platforms: [ spotify ]
 sources:
  - [ "Spotify Blog Post", "https://newsroom.spotify.com/2018-05-10/spotify-announces-new-hate-content-and-hateful-conduct-public-policy/" ]

--- a/website/content/events/theguncollective-begins-to-leave-patreon/index.md
+++ b/website/content/events/theguncollective-begins-to-leave-patreon/index.md
@@ -2,7 +2,7 @@
 date: 2019-08-21
 title: TheGunCollective Officially Begins to Leave Patreon
 image: /img/logos/theguncollective.jpg
-preview: Patreon explicity says their ToS apply to your brand, both on AND OFF Patreon
+summary: Patreon explicity says their ToS apply to your brand, both on AND OFF Patreon
 platforms: [ patreon ]
 tags: [ walked-away ]
 sources:

--- a/website/content/events/twitter-bans-blonde/index.md
+++ b/website/content/events/twitter-bans-blonde/index.md
@@ -2,7 +2,6 @@
 date: 2017-11-28
 title: Twitter Bans Blonde
 image: /img/people/blonde.jpg
-preview: Shortly after being temporarily suspended twice within two weeks
 profiles: [ blonde ]
 platforms: [ twitter ]
 tags: [ banned ]

--- a/website/content/events/twitter-bans-bnl-for-reporting-on-biden-ukraine/index.md
+++ b/website/content/events/twitter-bans-bnl-for-reporting-on-biden-ukraine/index.md
@@ -2,7 +2,6 @@
 date: 2019-11-20
 title: Twitter Bans BNL After Tweeting Link to Biden-Ukraine Article
 image: /img/logos/breakingnlive.jpg
-preview: Twitter banned @BreakingNLive for being "spam" after they tweeted out a link to a Biden-Ukraine article.
 platforms: [ twitter ]
 tags: [ banned ]
 sources:

--- a/website/content/events/twitter-suspends-andy-ngo/index.md
+++ b/website/content/events/twitter-suspends-andy-ngo/index.md
@@ -2,7 +2,7 @@
 date: 2019-11-25
 title: Twitter Suspends Andy Ngo For Tweeting Verifiable Statistics
 image: /img/people/andy-ngo.jpg
-preview: Objective, verifiable, empirical statistics are now hate speech on Twitter.
+summary: Objective, verifiable, empirical statistics are now hate speech on Twitter.
 profiles: [ andy-ngo ]
 platforms: [ twitter ]
 tags: [ suspended ]

--- a/website/content/events/twitter-suspends-blonde-for-banter/index.md
+++ b/website/content/events/twitter-suspends-blonde-for-banter/index.md
@@ -2,7 +2,6 @@
 date: 2017-11-02
 title: Twitter Suspends Blonde For Banter
 image: /img/people/blonde.jpg
-preview: Literally just bantering with one of her followers
 profiles: [ blonde ]
 platforms: [ twitter ]
 tags: [ suspended ]

--- a/website/content/events/twitter-suspends-james-woods-for-tweeting-a-meme/index.md
+++ b/website/content/events/twitter-suspends-james-woods-for-tweeting-a-meme/index.md
@@ -2,7 +2,6 @@
 date: 2018-09-20
 title: Twitter Suspends Actor James Woods For Tweeting a Meme
 image: /img/people/james-woods.jpg
-preview: And Twitter classified this as election meddling, which is just rich lol
 platforms: [ twitter ]
 tags: [ suspended ]
 sources:

--- a/website/content/events/wranglerstar-leaves-patreon/index.md
+++ b/website/content/events/wranglerstar-leaves-patreon/index.md
@@ -2,7 +2,7 @@
 date: 2018-12-19
 title: Wranglerstar Leaves Patreon
 image: /img/logos/wranglerstar.png
-preview: '"As of this morning, I have pulled all support from Patreon"'
+summary: '"As of this morning, I have pulled all support from Patreon"'
 platforms: [ patreon ]
 tags: [ walked-away ]
 sources:

--- a/website/content/events/youtube-deletes-infinite-elgintensity-video-on-trans-cyclist/index.md
+++ b/website/content/events/youtube-deletes-infinite-elgintensity-video-on-trans-cyclist/index.md
@@ -2,7 +2,7 @@
 date: 2019-10-25
 title: YouTube Deletes InfiniteElgintensity Video About Trans Cyclist
 image: /img/people/infinite-elgintensity.jpg
-preview: Please go watch the video on BitChute. It's hilarious
+summary: Please go watch the video on BitChute. It's hilarious.
 platforms: [ youtube ]
 tags: [ content-removed ]
 sources:

--- a/website/content/events/youtube-gets-caught-shadow-banning-tulsi-gabbard-in-the-us/index.md
+++ b/website/content/events/youtube-gets-caught-shadow-banning-tulsi-gabbard-in-the-us/index.md
@@ -1,8 +1,7 @@
 ---
 date: 2019-10-22
-title: YouTube Gets Caught Shadow Banning Tulsi Gabbard ONLY in the US
+title: YouTube Shadow Bans Presidential Candidate Tulsi Gabbard in US *ONLY*
 image: /img/people/tulsi-gabbard.jpg
-preview: Shadow banning a candidate in the country for which she's running to be President
 platforms: [ youtube ]
 tags: [ shadow-banned ]
 sources:

--- a/website/content/events/youtube-removes-dr-cretella-gender-dysphoria-video/index.md
+++ b/website/content/events/youtube-removes-dr-cretella-gender-dysphoria-video/index.md
@@ -2,7 +2,7 @@
 date: 2019-11-05
 title: YouTube Removes Dr. Cretella's Gender Dysphoria Video
 image: /img/people/dr-michelle-cretella.png
-preview: '"...if you want to cut off a healthy arm or a healthy leg, you''re mentally ill. But..."'
+summary: '"...if you want to cut off a healthy arm or a healthy leg, you''re mentally ill. But..."'
 platforms: [ youtube ]
 tags: [ content-removed ]
 sources:

--- a/website/layouts/partials/cards/event.html
+++ b/website/layouts/partials/cards/event.html
@@ -1,11 +1,10 @@
-{{ $eventIcon := partialCached "icon" (dict "name" "event" "size" "") "event-card-event" }}
+{{ $eventIcon := partialCached "icon" (dict "name" "event" "size" "") "ece" }}
 
 <!--
  An event card is a card link containing two top level sections:
  1) the header (image, title, meta) and 2) the text preview.
 -->
 <a class="event card" href="{{ .RelPermalink }}" title="{{ .Title }}">
-	<!-- Image, title, meta -->
 	<header>
 		<img src="{{ .Params.image }}" loading="lazy">
 
@@ -15,6 +14,5 @@
 		</div>
 	</header>
 
-	<!-- Preview -->
 	<p>{{ .Summary | truncate 90 }}</p>
 </a>

--- a/website/layouts/partials/cards/event.html
+++ b/website/layouts/partials/cards/event.html
@@ -16,5 +16,5 @@
 	</header>
 
 	<!-- Preview -->
-	<p>{{ .Params.preview | default .Summary | truncate 90 }}</p>
+	<p>{{ .Summary | truncate 90 }}</p>
 </a>


### PR DESCRIPTION
...as well as drop unnecessary `preview` values leftover from before `plainify`.

This 100% removes `.Params.preview` from the project events.