### PR TITLE
uiux: Redesign the Event single page.

### DIFF
--- a/website/assets/cards.css
+++ b/website/assets/cards.css
@@ -12,7 +12,7 @@
 	height: 100%;
 	transition: border .4s cubic-bezier(.4,0,.6,1);
 }
-.card:after {
+.card:after, .chip:after {
 	content: "";
 	background: var(--cardBefore);
 	border-radius: var(--radius);
@@ -26,7 +26,7 @@ a.card:hover {
 	border-color: #aaa;
 	text-decoration: none;
 }
-a.card:hover:after {
+a.card:hover:after, .chip:hover:after {
 	opacity: 0.15;
 }
 
@@ -72,11 +72,8 @@ a.card:hover:after {
 }
 
 .profile.card {
+	--imgSize: 48px;
 	border-radius: var(--radius) var(--radius) 0 0;
-}
-.profile.card > header p {
-	margin: 0;
-	font-size: 0.9rem;
 }
 .profile.card > header u {
 	color: var(--caption);
@@ -85,23 +82,40 @@ a.card:hover:after {
 	top: 0.5rem; right: 0.75rem;
 	text-decoration: none;
 }
+.profile.card > header p {
+	color: var(--caption);
+	font-size: 0.85rem;
+	margin: 0.33rem 0 0 0;
+}
+.profile.card > p {
+	font-size: 85%;
+}
 .profile.card + section {
 	background: var(--cardTitleBg);
 	border: var(--border1);
 	border-top: 1px solid transparent;
 	border-radius: 0 0 4px 4px;
-	padding: 0.25rem 1rem;
+	padding: 0.25rem;
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;
 }
 .profile.card + section a {
-	margin: 0.5rem 1rem 0.5rem 0;
+	padding: 0.5rem;
+	border-radius: 50%;
+}
+.profile.card + section a:hover {
+	background: var(--shadowColor);
+}
+.profile.card + section a img {
+	width: 24px !important;
+	height: 24px !important;
 }
 
 .tag.card {
 	display: flex;
 	align-items: center;
+	font-size: 0.9rem;
 }
 .tag.card > :first-child {
 	background: var(--cardTitleBg);
@@ -109,7 +123,15 @@ a.card:hover:after {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 	margin-right: 1rem;
-	padding: 0.75rem;
+	padding: 0.6rem;
+	width: 40px !important;
+	height: 40px !important;
+}
+.tag.card > u {
+	color: var(--caption);
+	position: absolute;
+	right: 0;
+	text-decoration: none;
 }
 .tag.card div[data-count] {
 	display: flex;

--- a/website/assets/drawer.css
+++ b/website/assets/drawer.css
@@ -14,7 +14,7 @@ input[id^="toggle"] ~ label:not([for="toggleNav"]) {
 	background: #03A9F4;
 	border-radius: 50%;
 	box-shadow: 3px 3px 10px 4px var(--shadowColor);
-	padding: 0.9rem;
+	padding: 0.85rem 0.9rem 0.9rem 0.85rem;
 	z-index: 3;
 }
 input[id^="toggle"] ~ label:not([for="toggleNav"]):after {

--- a/website/assets/general.css
+++ b/website/assets/general.css
@@ -144,42 +144,30 @@ h3[data-count] {
 
 .chip {
 	--c: #607D8B;
-	--height: 23px;
-	background: var(--c);
-	color: #fff;
-	height: var(--height);
-	border: 1px solid transparent;
+	--height: 28px;
+	background: var(--cardTitleBg);
+	border: var(--border1);
 	border-radius: var(--height);
+	color: var(--articleBold);
 	display: inline-flex;
 	align-items: center;
-	font-size: 0.75rem;
-	margin: 0.2rem;
+	font-size: 0.8rem;
+	height: var(--height);
+	margin: 0.25rem;
 	padding: 0 12px;
 	position: relative;
 }
 .chip:hover {
 	text-decoration: none;
-	border: 1px solid #fff;
+	border: 1px solid var(--para);
 }
 .chip:after {
-	content: "";
-	border-radius: var(--height);
-	position: absolute;
-	top: 0; right: 0; bottom: 0; left: 0;
+	transition: none !important;
 }
-.chip:hover:after {
-	background: rgba(0,0,0,0.15);
+.chip > img {
+	width: 16px !important;
+	height: 16px !important;
+	margin-right: 0.5rem;
 }
-.chip.amazon {    --c: #ff9800 }
-.chip.apple {     --c: #f48fb1 }
-.chip.facebook {  --c: #3f51b5 }
-.chip.google {    --c: #448Aff }
-.chip.instagram { --c: #e040fb }
-.chip.patreon {   --c: #ff8a80 }
-.chip.pinterest { --c: #c62828 }
-.chip.reddit {    --c: #ff5722 }
-.chip.spotify {   --c: #4caf50 }
-.chip.twitter {   --c: #03a9f4 }
-.chip.youtube {   --c: #e53935 }
 
 .mb-8 { margin-bottom: 2rem !important }

--- a/website/assets/pages/events.css
+++ b/website/assets/pages/events.css
@@ -1,38 +1,135 @@
-main.event {
-	max-width: 900px;
-	margin: auto;
+.event.cntr {
+	width: 1400px;
 }
-main.event > header {
+.event.cntr > .row {
+	justify-content: center;
+}
+@media (min-width: 900px) and (max-width:1249px) {
+	.event.cntr {
+		width: 900px;
+	}
+}
+.crux > header {
 	border-bottom: var(--border1);
 	padding-bottom: 1.75rem;
 	margin-bottom: 2.5rem;
 }
-main.event > header u {
+.crux > header u {
 	color: var(--caption);
 	display: block;
 	margin-top: 1rem;
 	text-decoration: none;
 }
-main.event > article {
+.crux > article {
 	border-bottom: var(--border1);
 	margin-bottom: 1.5rem;
 }
 @media (max-width: 450px) {
-	main.event > header {
+	.crux > header {
 		flex-direction: column;
 		text-align: center;
 	}
-	main.event > header h1 {
+	.crux > header h1 {
 		margin-top: 2rem;
 	}
 }
+.info {
+	border-left: var(--border1);
+	padding: 0;
+}
+.info > header {
+	background: var(--cardTitleBg);
+	border-bottom: var(--border1);
+	color: var(--para);
+	font-size: 1.5rem;
+	margin-bottom: 0.5rem;
+	padding: 1.25rem 0.75rem;
+}
+.info > section {
+	overflow-y: auto;
+	padding: 0.75rem;
+}
+.info, .info > section {
+	scrollbar-width: none;
+}
+.info::-webkit-scrollbar, .info > section::-webkit-scrollbar {
+	width: 0 !important;
+}
+.info > section > hr {
+	margin: 2rem 0;
+}
+.info > section > div > h3 {
+	display: flex;
+	align-items: center;
+	font-size: 1.1rem;
+	margin-bottom: 0.5rem;
+}
+.info > section > div > h3:before {
+	content: "";
+	background: var(--caption);
+	display: inline-flex;
+	margin: 0 0.75rem 0 0.5rem;
+	width: 10px;
+	height: 10px;
+}
+.info > section > div > div {
+	padding: 0.4rem 0.75rem;
+}
+.platforms h3 {
+	margin-bottom: -0.25rem !important;
+}
+.tags > div > div:not(:first-child), .platforms > div > a {
+	margin-top: 0.75rem;
+	margin-bottom: 0;
+}
+.profiles > div > div {
+	margin-bottom: 1rem;
+}
 
-#toggleProfiles + label:after {
-	background: no-repeat center/100% url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFgAAABYAQMAAABLW6J3AAAABlBMVEUAAAD///+l2Z/dAAAAAXRSTlMAQObYZgAAAKlJREFUOMvdkDEKwzAUQx06ePQRfJP6YoUEOvRagV7EvYFHDyGqrEA/NLRTMiQCWW8w3192J9aNvi54weA6jOKA7DyKODIDqjgxIyZxz0yYVwxmD3xzByY97M1/drA9rcuqo3XXn9DZSXMb4PaSzbd9PvsnQOu0fvRI9i3prOtAYceqWkwek+oyI1QYYAYe+iqKA9Su6aGhC9/FXvzUA0H8ossPrpvxAfUGmls1d6OdE4kAAAAASUVORK5CYII=');
+@media (max-width: 1249px) {
+	#toggleInfo:checked ~ .row > .info {
+		transform: translateX(0);
+	}
+	#toggleInfo + label > .overlay {
+		width: calc(100% - 400px);
+	}
+	#toggleInfo + label:after {
+		background: no-repeat center/100% url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAb1BMVEUAAAD+///8/f78/f7////+///+///8/f72+fv9/f7q8Pb9/f79/f7+/v/4+vz6/P38/f39/v78/f77/P37/P35+/z////5+/z+/v/+/v/8/f7+/v/8/f76+/35+/z+/v/9/f79/f77/P319/r///8zIQB3AAAAJHRSTlMAzDY64ZruThyfBbGvZSkiyZR2Vy4K5RPb9NWIXD4U8be0RROo76PuAAABmElEQVRYw92X2XLCMAxFa+otC6YJgbB30/9/Y2lGjAeQnUSavvQ+InTAWmzp5e/kXWsqdVVlWudnOpfOaLiTNq6c7B4aC4RsEya5dzUkVXWj7n0BWRWXvP/awojsOuO+KWCCik0ycQomSSWSutIwUXpF+m/hWXul9sTHW4Lgid9/X5bXojoRZO2f4qeIgIc0Wz1Gkor/6WZ0VC4e8k8dNJqp8NzVw4Wqn89o/6Aqqh85ANTRXkH+EB1Q2sUv0BUSOyvRf183+xkg+xfDSMF974BWQEADKcL517xI+UOD95fN9I0xKtPaJZYJW24AGD7AYI7Y0kOrgEA+G4LjEnXMBqFNWl9fUAtIqcUYMgAxipUEUF2tSgJQ/wMgDKI8jfJCchKAw2ZiAzy2MxegB7PhA8xgdnyAw0uVC7AlXutcQIP2wAWE+LSxAHV8XHmAjn7eacDIjNLb+QDbEyPOHMDDyFvMBRTEmDcHoDbEoDkDoP2UUffwhjoQo65w2JaO+9KFQ7jyCJeuXrT21Z1w8RSuvtzlu84t33L9AJTpah8YI+UXAAAAAElFTkSuQmCC');
+	}
+	.info {
+		background: var(--bodyBg);
+		box-shadow: 0 0 transparent, -15px 0 20px 0 var(--shadowColor);
+
+		position: fixed;
+		top: var(--navHeight);
+		right: 0;
+
+		width: 400px;
+		max-width: 100%;
+		height: 100%;
+		max-height: 100%;
+		overflow-y: auto;
+
+		transition: transform 0.35s;
+		transform: translateX(110%);
+		z-index: 2 !important;
+	}
+	.info > section {
+		padding-bottom: 11rem;
+		top: 0;
+	}
 }
-.profiles.content > header:before {
-	background: no-repeat center/100% url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAY1BMVEUAAACgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKAwX8KIAAAAIHRSTlMABbb88Av3aBouD33i08RK6b8myXJhUdmsRIU3oJ9auW9yIiwAAAFESURBVFjD7dVbbsMgEIXhIQwYzMX3W9Kk3v8q24dWcu1Jwziq1Ej+F/AheDjA/GQHcAB/D0iNIaCWOwHduIsAEBfX6D3AcDPwlbkNfCDWsKiOXKAy8CNT8QBvYZX1HEA62OQkA/BmCxjPAK5AdGUABQUUDMBQgEkHSkUBqkwGMKeAHNOvUFNAzXiDjAIyBhApIDIAnGDThAxgHhWsUuPMAXS3BjrNAmbsBSwSPXIHBdvFLVSL/EnTsRffx0e9a5VlOBfWFucgn/gXpHztn2nW5RBKvQeQ6Ktzb3P1WV4X7uRRMoBydNNqEtTkRp8IDK2lB6XOGvkQ0E2n4G6ieMffgaZbHE4TJ3kfQJfDw1RX3gPiBZKyFQ1UBhIzFQWgheQsEsCbSgfUGwG0wKjdAjLjAJn8l4BgRABzODEKLzNpB3AAiX0ALfSCW2e8siQAAAAASUVORK5CYII=');
-}
-.profiles.content > section > * {
-	margin: 1rem;
+@media (min-width: 1250px) {
+	.crux {
+		padding-right: 2rem;
+	}
+	.info > section {
+		max-height: calc(100vh - calc(2 * var(--navHeight)));
+		position: -webkit-sticky;
+		position: sticky;
+		top: calc(var(--navHeight) + 0.5rem);
+	}
+	.info > header {
+		display: none;
+	}
 }

--- a/website/data/bigtechNames.yaml
+++ b/website/data/bigtechNames.yaml
@@ -1,0 +1,2 @@
+youtube: YouTube
+linkedin: LinkedIn

--- a/website/layouts/alttech/single.html
+++ b/website/layouts/alttech/single.html
@@ -26,7 +26,7 @@
 		<p>
 			<b>Similar to:</b>
 			{{ range .Params.altfor }}
-				<a href="/{{ . }}/" class="chip {{ . }}">{{ . }}</a>
+				{{ partialCached "bigtech-chip" . . }}
 			{{ end }}
 		</p>
 

--- a/website/layouts/events/single.html
+++ b/website/layouts/events/single.html
@@ -6,35 +6,92 @@
 	{{ .Summary | truncate 69 | plainify }}
 {{ end }}
 
-{{ define "main" }}
-	{{ $class := and (.Param `profiles`) `aside-parent` }}
+{{ define "partials/event-platforms" }}
+	<div class="platforms">
+		<h3>Platforms:</h3>
+		<div>
+			{{ range . }}
+				{{ partialCached "bigtech-chip" . . }}
+			{{ end }}
+		</div>
+	</div>
+{{ end }}
 
-	<div class="cntr {{ $class }}">
-		<main class="event">
-			<header>
-				<img src="{{ .Params.image }}" width="128" height="128" loading="lazy">
-
+{{ define "partials/event-tags" }}
+	<hr>
+	<div class="tags">
+		<h3>Tags:</h3>
+		<div>
+			{{ range . }}
 				<div>
-					<h1>{{ .Title }}</h1>
-					<u>{{ .Date.Format "Jan 2, 2006" }}</u>
+					{{ partialCached "tag-card" . . }}
 				</div>
-			</header>
+			{{ end }}
+		</div>
+	</div>
+{{ end }}
 
-			<article>{{ .Content }}</article>
-
-			<h3>Sources :</h3>
-			<ol class="sources">
-				{{ range .Params.sources }}
-					{{ $href := index . 1 }}
-					{{ $text := index . 0 | default $href }}
-					<li><a href="{{ $href }}" target="_blank">{{ $text }}</a></li>
+{{ define "partials/event-profiles" }}
+	<hr>
+	<div class="profiles">
+		<h3>Profiles:</h3>
+		<div>
+			{{ range . }}
+				{{ with site.GetPage (printf "/profiles/%s" .) }}
+					<div>
+						{{ partialCached "cards/profile" . . }}
+					</div>
 				{{ end }}
-			</ol>
-		</main>
+			{{ end }}
+		</div>
+	</div>
+{{ end }}
 
-		<!-- The profiles of the people involved in the event (if any). -->
-		{{ with .Params.profiles }}
-			{{ partialCached "event-profiles.html" . . }}
-		{{ end }}
+{{ define "main" }}
+	<div class="event cntr">
+		<input id="toggleInfo" type="checkbox">
+		<label for="toggleInfo"><div class="overlay"></div></label>
+
+		<div class="row">
+			<div class="crux col lg-8">
+				<header>
+					<img src="{{ .Params.image }}" width="128" height="128" loading="lazy">
+
+					<div>
+						<h1>{{ .Title }}</h1>
+						<u>{{ .Date.Format "Jan 2, 2006" }}</u>
+					</div>
+				</header>
+
+				<article>{{ .Content }}</article>
+
+				<h3>Sources:</h3>
+				<ol class="sources">
+					{{ range .Params.sources }}
+						{{ $href := index . 1 }}
+						{{ $text := index . 0 | default $href }}
+						<li><a href="{{ $href }}" target="_blank">{{ $text }}</a></li>
+					{{ end }}
+				</ol>
+			</div>
+
+			<div class="info col lg-4">
+				<header>Event Info</header>
+
+				<section>
+					{{ with .Params.platforms }}
+						{{ partialCached "event-platforms" . . }}
+					{{ end }}
+
+					{{ with .Params.tags }}
+						{{ partialCached "event-tags" . . }}
+					{{ end }}
+
+					{{ with .Params.profiles }}
+						{{ partialCached "event-profiles" . . }}
+					{{ end }}
+				</section>
+			</div>
+		</div>
 	</div>
 {{ end }}

--- a/website/layouts/partials/cards.html
+++ b/website/layouts/partials/cards.html
@@ -54,7 +54,7 @@
 {{ end }}
 
 {{ define "partials/cards/bigtech" }}
-	<a class="failing card" href="{{ .RelPermalink }}">
+	<a class="card" href="{{ .RelPermalink }}">
 		<header>
 			<img src="/img/logos/{{ .Title | anchorize }}.png" loading="lazy">
 
@@ -65,5 +65,26 @@
 		</header>
 
 		<p>{{ .Summary | truncate 125 | plainify | safeHTML }}</p>
+	</a>
+{{ end }}
+
+{{ define "partials/tag-card" }}
+	{{ with site.GetPage (printf "/tags/%s" .) }}
+		<a class="tag card" href="{{ .RelPermalink }}">
+			{{ with .Params.image }}
+				<img src="{{ . }}" loading="lazy">
+			{{ end }}
+
+			{{ .LinkTitle | default ($ | title) }}
+
+			<u>&#10132;</u>
+		</a>
+	{{ end }}
+{{ end }}
+
+{{ define "partials/bigtech-chip" }}
+	<a href="/{{ . }}/" class="chip">
+		<img src="/img/logos/{{ . }}.png">
+		{{ index site.Data.bigtechNames . | default (. | title) }}
 	</a>
 {{ end }}

--- a/website/layouts/partials/tags-drawer.html
+++ b/website/layouts/partials/tags-drawer.html
@@ -13,7 +13,7 @@
 				<div>
 					<a class="tag card" href="{{ .Page.RelPermalink }}">
 						{{ with .Page.Params.image }}
-							<img src="{{ . }}" width="48" height="48" loading="lazy">
+							<img src="{{ . }}" loading="lazy">
 						{{ end }}
 
 						<div data-count="{{ len .Page.Pages }}">


### PR DESCRIPTION
Primarily, display Event info on each event's page in a sidebar that moves to a drawer on mobile. This info includes which platforms and profiles were involved along with the event's tags.

Other refactors (necessary for this redesign) include:
* Redesign the chips for BigTech platforms and adjust their use on AltTech pages.
* Slight redesign to tag cards.