### PR TITLE
refactor: Trim down the navbar HTML in favor of its CSS.

### DIFF
--- a/website/assets/navbar.css
+++ b/website/assets/navbar.css
@@ -1,4 +1,4 @@
-nav {
+nav, nav ~ aside:before {
 	background: var(--navBg);
 	box-shadow: 0 4px 16px -1px rgba(0,0,0,.75);
 	display: flex;
@@ -19,7 +19,7 @@ nav a {
 nav a:hover {
 	color: #888;
 }
-[for="toggleNav"]:after {
+nav ~ label:after {
 	content: "☰";
 	color: #ddd;
 	font-size: 36px;
@@ -30,7 +30,7 @@ nav a:hover {
 	top: 0;
 	z-index: 10;
 }
-[for="toggleNav"] + aside {
+nav ~ aside {
 	--asideW: 325px;
 	background: var(--navBg);
 	border-left: none;
@@ -38,9 +38,22 @@ nav a:hover {
 	top: 0;
 	z-index: 9 !important;
 }
-[for="toggleNav"] + aside > a {
+nav ~ aside:before {
+	content: "";
+}
+nav ~ aside > a {
 	color: var(--navColor);
 	display: block;
 	text-align: right;
 	padding: 1.5rem;
+}
+@media (max-width: 599px) {
+	nav > a:not(:first-child) {
+		display: none;
+	}
+}
+@media (min-width: 600px) {
+	nav ~ label, nav ~ aside {
+		display: none;
+	}
 }

--- a/website/layouts/partials/navbar.html
+++ b/website/layouts/partials/navbar.html
@@ -6,22 +6,16 @@
 		<img src="/img/bigtechfail-{{ $img }}.png" height="36" width="auto" loading="lazy">
 	</a>
 
-	<div class="items hide-xs">
-		{{ range $links }}
-			<a href="{{ .href }}">{{ .text }}</a>
-		{{ end }}
-	</div>
+	{{ range $links }}
+		<a href="{{ .href }}">{{ .text }}</a>
+	{{ end }}
 </nav>
 
-<div class="hide-sm-and-up">
-	<input id="toggleNav" type="checkbox">
-	<label for="toggleNav"></label>
+<input id="toggleNav" type="checkbox">
+<label for="toggleNav"></label>
 
-	<aside>
-		<nav></nav>
-
-		{{ range $links }}
-			<a href="{{ .href }}">{{ .text }}</a>
-		{{ end }}
-	</aside>
-</div>
+<aside>
+	{{ range $links }}
+		<a href="{{ .href }}">{{ .text }}</a>
+	{{ end }}
+</aside>


### PR DESCRIPTION
In the quest to continually simplify, I found many things within the navbar's HTML layout that could be extracted in favor of CSS rule sets or use of CSS pseudo elements.