### PR TITLE
refactor: Use a data attr and :before pseudo element for event card.

### DIFF
--- a/website/assets/cards.css
+++ b/website/assets/cards.css
@@ -56,7 +56,9 @@ a.card:hover:after, .chip:hover:after {
 .event.card {
 	--imgSize: 92px;
 }
-.event.card header h2 {
+.event.card h2:before {
+	content: attr(data-t);
+	color: var(--articleBold);
 	display: -webkit-box;
 	font-size: 1.15rem;
 	line-height: 1.4;
@@ -65,10 +67,9 @@ a.card:hover:after, .chip:hover:after {
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2
 }
-.event.card header u {
-	color: #8f8f8f;
+.event.card h2 {
+	color: var(--caption);
 	font-size: 0.9rem;
-	text-decoration: none;
 }
 
 .profile.card {

--- a/website/layouts/events/single.html
+++ b/website/layouts/events/single.html
@@ -56,7 +56,7 @@
 			<div class="crux col lg-8">
 				<header>
 					<img src="{{ .Params.image }}" width="128" height="128" loading="lazy">
-					<h1 data-date="{{ .Date.Format `Jan 2, 2006` }}">{{ .Title }}</h1>
+					<h1 data-date="{{ .Date.Format `2 Jan 2006` }}">{{ .Title }}</h1>
 				</header>
 
 				<article>{{ .Content }}</article>

--- a/website/layouts/partials/cards.html
+++ b/website/layouts/partials/cards.html
@@ -6,11 +6,7 @@
 	<a class="event card" href="{{ .RelPermalink }}" title="{{ .Title }}">
 		<header>
 			<img src="{{ .Params.image }}" loading="lazy">
-
-			<div>
-				<h2>{{ .Title }}</h2>
-				<u>{{ .Date.Format "Jan 2, 2006" }}</u>
-			</div>
+			<h2 data-t="{{ .Title }}">{{ .Date.Format `2 Jan 2006` }}</h2>
 		</header>
 
 		<p>{{ .Summary | truncate 90 }}</p>


### PR DESCRIPTION
The `overflow: hidden` on the parent apparently applies to it's pseudo elements as well. Therefore, the event card `h2` is reversed: the `h2` inner content is the date and the `:before` pseudo element is the title / heading, where the `overflow: hidden` (due to the necessity to `line-clamp` properly) only applies to itself.