### PR TITLE
uiux: Remove corpo links from within articles.

### DIFF
--- a/website/content/events/amazon-removes-when-harry-became-sally/index.md
+++ b/website/content/events/amazon-removes-when-harry-became-sally/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'twitter.com/MarkDice/status/1363987576659451905', 'archive.is/ZcfFr' ]
 ---
 
-[Amazon](/amazon/) removed a book called _When Harry Became Sally_ by Ryan T.
+Amazon removed a book called _When Harry Became Sally_ by Ryan T.
 Anderson without sending a single notification or providing any explanation:
 
 > I hope you’ve already bought your copy, cause Amazon just removed my book

--- a/website/content/events/apple-blocks-proton-updates-myanmar/index.md
+++ b/website/content/events/apple-blocks-proton-updates-myanmar/index.md
@@ -14,7 +14,7 @@ than 2,500. On March 17, the United Nations asked Myanmar citizens to gather
 and submit any evidence of "crimes against humanity." They even [explicitly
 recommended using ProtonMail and
 Signal](https://archive.is/Zvh3i#selection-749.0-749.272). _On that same day_,
-[Apple](/apple/) blocked updates for the ProtonVPN app, which saw exponential
+Apple blocked updates for the ProtonVPN app, which saw exponential
 growth during and after the coup, because of the language used in its
 description, specifically the "challenging governments" part. Andy Yen, one of
 the founders of Proton Technologies,

--- a/website/content/events/apple-removes-parler-from-app-store/index.md
+++ b/website/content/events/apple-removes-parler-from-app-store/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'ZeroHedge ""This Was A Coordinated Attack": Parler CEO Speaks Out After Amazon Boots From AWS, Vows To Rebuild ''From Scratch''" by Tyler Durden (9 Jan 2021)', 'archive.is/uAHMi' ]
 ---
 
-[Apple](/apple/) removed the Parler app (a Twitter alternative) from the App
+Apple removed the Parler app (a Twitter alternative) from the App
 Store the day after the app was [removed from the Google Play
 Store](/e/google-removes-parler-from-play-store/). This move from Apple
 came a few days after the rioting in the US capitol, and after Parler saw

--- a/website/content/events/apple-removes-parler-from-app-store/index.md
+++ b/website/content/events/apple-removes-parler-from-app-store/index.md
@@ -22,7 +22,7 @@ spokesperson gave a statement that included the following:
 > threats to people’s safety. We have suspended Parler from the App Store until
 > they resolve these issues.
 
-Towards the end of the day, [Amazon](/amazon/) announced that they would be
+Towards the end of the day, Amazon announced that they would be
 terminating Parler's servers on Amazon Web Services (AWS). John Matze, the CEO
 of Parler, made [the following statement](https://archive.is/EmECm):
 

--- a/website/content/events/facebook-bans-robinhood-stock-traders-group/index.md
+++ b/website/content/events/facebook-bans-robinhood-stock-traders-group/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'Summit News "Facebook Bans ‘Robinhood Stock Traders Group’ With 157,000 Members" by Paul Joseph Watson (29 Jan 2021)', 'archive.is/ql5PB' ]
 ---
 
-[Facebook](/facebook/) banned the _Robinhood Stock Traders_ group, the largest
+Facebook banned the _Robinhood Stock Traders_ group, the largest
 community of Robinhood traders on Facebook, for "adult sexual exploitation"
 violations. The group had a number of members who were participating in the
 coordinated short squeezing efforts of the r/wallstreetbets sub-reddit.

--- a/website/content/events/facebook-bans-stop-the-steal/index.md
+++ b/website/content/events/facebook-bans-stop-the-steal/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'facebook.com/groups/stopthesteal2020 (archived removal)', 'archive.vn/ptPSu' ]
 ---
 
-[Facebook](/facebook/) removed a group named _Stop The Steal_ that was formed
+Facebook removed a group named _Stop The Steal_ that was formed
 to help organize efforts to prevent cheating in the 2020 US election. The group
 was less than two days old and had accumulated over **350k members**.
 

--- a/website/content/events/facebook-bans-tsidpod/index.md
+++ b/website/content/events/facebook-bans-tsidpod/index.md
@@ -15,7 +15,7 @@ sources:
  - [ 'twitter.com/tsidpod/status/1347658911378272259', 'archive.is/iDsby' ]
 ---
 
-[Facebook](/facebook/) took drastic action against Dan Smotz, host of a podcast
+Facebook took drastic action against Dan Smotz, host of a podcast
 called [_The System Is Down_](/profiles/tsid/), after he published an episode
 titled _204: Is Cue A-non Dead? Is Epstein Alive? Where's The Kraken?
 #TrustThePlan? w. Scott McElroy_. Facebook not only banned Smotz's personal

--- a/website/content/events/facebook-bans-walkaway-campaign/index.md
+++ b/website/content/events/facebook-bans-walkaway-campaign/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'twitter.com/WebCoderz/status/1347595502033002498', 'archive.is/jgnDq' ]
 ---
 
-[Facebook](/facebook/) banned the [#WalkAway
+Facebook banned the [#WalkAway
 Campaign](https://www.walkawaycampaign.com/about-more), as well as every one of
 its team members, following [a hitpiece](https://archive.is/Wvuz8) being
 published by ABC about the group. This move by Facebook came shortly after the

--- a/website/content/events/facebook-disables-livestreaming-for-oann/index.md
+++ b/website/content/events/facebook-disables-livestreaming-for-oann/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'facebook.com/OneAmericaNewsNetwork/posts/2353616441450125', 'archive.is/2QDeR' ]
 ---
 
-[Facebook](/facebook/) removed the ability for _One America News Network_ to
+Facebook removed the ability for _One America News Network_ to
 livestream to the network's paid supporters and canceled all payments.
 
 > At this time, Facebook is no longer allowing One America News to live stream

--- a/website/content/events/facebook-expands-covid-misinfo-policy/index.md
+++ b/website/content/events/facebook-expands-covid-misinfo-policy/index.md
@@ -10,7 +10,7 @@ extra:
  - [ 'ZeroHedge "WHO Concludes That Coronavirus "Came From Animal," Not Wuhan Lab" by Tyler Durden (9 Feb 2021)', 'archive.is/HZRc3' ]
 ---
 
-[Facebook](/facebook/) announced the expansion of their efforts to "limit
+Facebook announced the expansion of their efforts to "limit
 misinformation about COVID-19" to include, among other things, removing content
 that claims the virus is "manufactured":
 

--- a/website/content/events/facebook-instagram-ban-elijah-schaffer/index.md
+++ b/website/content/events/facebook-instagram-ban-elijah-schaffer/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'Reclaim The Net "Facebook and Instagram ban BlazeTV reporter Elijah Schaffer" by Tom Parker (8 Jan 2021)', 'reclaimthenet.org/facebook-instagram-ban-elijah-schaffer/' ]
 ---
 
-Facebook and [Instagram](/instagram/) permanently banned
+Facebook and Instagram permanently banned
 independent journalist Elijah Schaffer. There was no stated reason, but it was
 likely due to him simply being on the ground and reporting on the US capitol
 riots of January 6, 2020.

--- a/website/content/events/facebook-instagram-ban-elijah-schaffer/index.md
+++ b/website/content/events/facebook-instagram-ban-elijah-schaffer/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'Reclaim The Net "Facebook and Instagram ban BlazeTV reporter Elijah Schaffer" by Tom Parker (8 Jan 2021)', 'reclaimthenet.org/facebook-instagram-ban-elijah-schaffer/' ]
 ---
 
-[Facebook](/facebook/) and [Instagram](/instagram/) permanently banned
+Facebook and [Instagram](/instagram/) permanently banned
 independent journalist Elijah Schaffer. There was no stated reason, but it was
 likely due to him simply being on the ground and reporting on the US capitol
 riots of January 6, 2020.

--- a/website/content/events/facebook-proactively-works-with-fbi-capitol-riot/index.md
+++ b/website/content/events/facebook-proactively-works-with-fbi-capitol-riot/index.md
@@ -12,7 +12,7 @@ extra:
  - [ 'Forbes "The FBI Investigated Parler User’s Call For Proud Boys To Violently Attack Government Officials—Three Weeks Before The Capitol Hill Siege" by Thomas Brewster (14 Jan 2021)', 'archive.is/N5P2K' ]
 ---
 
-[Facebook](/facebook/) proactively worked with law enforcement by preserving
+Facebook proactively worked with law enforcement by preserving
 and providing the account data of users who were at the [US capitol
 riot](/t/us-capitol-riot/). A couple later, it was discovered that the company
 was even handing over the private messages of those users as well. As Thomas

--- a/website/content/events/facebook-restricts-mark-dice-again/index.md
+++ b/website/content/events/facebook-restricts-mark-dice-again/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'gab.com/MarkDice/posts/105629657057880226', 'gab.com/MarkDice/posts/105629657057880226' ]
 ---
 
-[Facebook](/facebook/) removed a post made by media analyst and political
+Facebook removed a post made by media analyst and political
 commentator Mark Dice, restricted the distribution of his page, and threatened
 to outright ban him:
 

--- a/website/content/events/facebook-restricts-ron-paul-for-no-reason/index.md
+++ b/website/content/events/facebook-restricts-ron-paul-for-no-reason/index.md
@@ -15,7 +15,7 @@ extra:
  - [ 'twitter.com/RonPaul/status/1349465640642482176', 'archive.is/Olm9s' ]
 ---
 
-[Facebook](/facebook/) restricted Ron Paul from creating new pages and managing
+Facebook restricted Ron Paul from creating new pages and managing
 his existing pages without citing a specific reason why. The notice on his
 account said it was "Due to repeatedly going against [Facebook's] Community
 Standards [...]", however, Ron Paul has never had any community standards

--- a/website/content/events/facebook-twitter-ban-antimedia/index.md
+++ b/website/content/events/facebook-twitter-ban-antimedia/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'reddit.com/r/conspiracy/comments/9ndg1w/facebook_bans_free_thought_project_press_for/', 'archive.is/8lIaQ' ]
 ---
 
-[Facebook](/facebook/) and Twitter permanently banned _The
+Facebook and Twitter permanently banned _The
 Anti-Media_, an independent media outlet, as part of a widespread purge of
 political groups and pages. Their Facebook page had over **2.1 million
 followers**, and their six year old Twitter account had nearly **48k

--- a/website/content/events/facebook-twitter-ban-antimedia/index.md
+++ b/website/content/events/facebook-twitter-ban-antimedia/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'reddit.com/r/conspiracy/comments/9ndg1w/facebook_bans_free_thought_project_press_for/', 'archive.is/8lIaQ' ]
 ---
 
-[Facebook](/facebook/) and [Twitter](/twitter/) permanently banned _The
+[Facebook](/facebook/) and Twitter permanently banned _The
 Anti-Media_, an independent media outlet, as part of a widespread purge of
 political groups and pages. Their Facebook page had over **2.1 million
 followers**, and their six year old Twitter account had nearly **48k

--- a/website/content/events/facebook-twitter-suppress-nypost-hunter-expose/index.md
+++ b/website/content/events/facebook-twitter-suppress-nypost-hunter-expose/index.md
@@ -38,7 +38,7 @@ sources:
  - [ 'twitter.com/andymstone/status/1316395902479872000', 'archive.is/eZu88' ]
 ---
 
-[Facebook](/facebook/) and [Twitter](/twitter/) suppressed [an
+[Facebook](/facebook/) and Twitter suppressed [an
 exposé](https://nypost.com/2020/10/14/email-reveals-how-hunter-biden-introduced-ukrainian-biz-man-to-dad/)
 published by the New York Post about Hunter Biden's corruption. Facebook
 spokesperson (and former Democrat Party opertative) Andy Stone confirmed that

--- a/website/content/events/facebook-twitter-suppress-nypost-hunter-expose/index.md
+++ b/website/content/events/facebook-twitter-suppress-nypost-hunter-expose/index.md
@@ -38,7 +38,7 @@ sources:
  - [ 'twitter.com/andymstone/status/1316395902479872000', 'archive.is/eZu88' ]
 ---
 
-[Facebook](/facebook/) and Twitter suppressed [an
+Facebook and Twitter suppressed [an
 exposé](https://nypost.com/2020/10/14/email-reveals-how-hunter-biden-introduced-ukrainian-biz-man-to-dad/)
 published by the New York Post about Hunter Biden's corruption. Facebook
 spokesperson (and former Democrat Party opertative) Andy Stone confirmed that

--- a/website/content/events/facebook-twitter-suppress-trump-flu-post/index.md
+++ b/website/content/events/facebook-twitter-suppress-trump-flu-post/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/realDonaldTrump/status/1313449844413992961', 'archive.is/c7ViI' ]
 ---
 
-[Facebook](/facebook/) and [Twitter](/twitter/) suppressed the following post
+[Facebook](/facebook/) and Twitter suppressed the following post
 made by President Trump after his release from the hospital due to COVID-19.
 
 > Flu season is coming up! Many people every year, sometimes over 100,000, and

--- a/website/content/events/facebook-twitter-suppress-trump-flu-post/index.md
+++ b/website/content/events/facebook-twitter-suppress-trump-flu-post/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/realDonaldTrump/status/1313449844413992961', 'archive.is/c7ViI' ]
 ---
 
-[Facebook](/facebook/) and Twitter suppressed the following post
+Facebook and Twitter suppressed the following post
 made by President Trump after his release from the hospital due to COVID-19.
 
 > Flu season is coming up! Many people every year, sometimes over 100,000, and

--- a/website/content/events/google-play-deletes-150k-robinhood-reviews/index.md
+++ b/website/content/events/google-play-deletes-150k-robinhood-reviews/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'Gizmodo "Google Deletes 100,000 Negative Reviews of Robinhood App From Angry Users" by Matt Novak (29 Jan 2021)', 'archive.is/bemOq' ]
 ---
 
-The [Google](/google/) Play Store purged over 150,000 negative reviews from
+The Google Play Store purged over 150,000 negative reviews from
 Robinhood, one of the most popular trading apps. These reviews poured in after
 Robinhood restricted the ability to buy certain stocks (like GameStop) that
 were selected by the online trading group r/wallstreetbets as targets for

--- a/website/content/events/google-play-threatens-minds-with-suspension/index.md
+++ b/website/content/events/google-play-threatens-minds-with-suspension/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'Styxhexenhammer666 "Google Targets Minds.com As the Billionaires'' Fascist Moves Continue" on BitChute (16 Jan 2021)', 'www.bitchute.com/video/0EcA6WqpYPw/' ]
 ---
 
-[Google](/google/) threatened the free-speech platform [Minds](/alttech/minds/)
+Google threatened the free-speech platform [Minds](/alttech/minds/)
 with removal from the Play Store due to the app hosting what Google deemed to
 be controversial content. In order to avoid being removed from the Play Store,
 Minds had to significantly reduce their mobile app functionality. The CEO Bill

--- a/website/content/events/google-removes-bitslide-from-play-store/index.md
+++ b/website/content/events/google-removes-bitslide-from-play-store/index.md
@@ -19,7 +19,7 @@ BitSlide, an unofficial Android app for the video hosting platform
 [BitChute](/alttech/bitchute/), was removed from the [Google](/google/) Play
 Store [for violating](notice.png) Google's "User Generated Content" policy. At
 the time of this writing, at least one of the offending videos cited by Google
-has been available for over a year on [YouTube](/youtube/), a video publishing
+has been available for over a year on YouTube, a video publishing
 site owned by Google, without so much as an adult content notice.
 
 > Google has suspended the @bitslide_app from their play store. If there is a

--- a/website/content/events/google-removes-bitslide-from-play-store/index.md
+++ b/website/content/events/google-removes-bitslide-from-play-store/index.md
@@ -16,7 +16,7 @@ sources:
 ---
 
 BitSlide, an unofficial Android app for the video hosting platform
-[BitChute](/alttech/bitchute/), was removed from the [Google](/google/) Play
+[BitChute](/alttech/bitchute/), was removed from the Google Play
 Store [for violating](notice.png) Google's "User Generated Content" policy. At
 the time of this writing, at least one of the offending videos cited by Google
 has been available for over a year on YouTube, a video publishing

--- a/website/content/events/google-removes-parler-from-play-store/index.md
+++ b/website/content/events/google-removes-parler-from-play-store/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'blog.mozilla.org/blog/2021/01/08/we-need-more-than-deplatforming/', 'archive.is/5gLNb' ]
 ---
 
-[Google](/google/) removed the Parler app (a Twitter alternative) from the Play
+Google removed the Parler app (a Twitter alternative) from the Play
 Store shortly after it saw record traffic due to Twitter banning Trump. A
 spokesperson for Google gave the following statement:
 

--- a/website/content/events/google-removes-third-party-bitchute-app-by-hexagod/index.md
+++ b/website/content/events/google-removes-third-party-bitchute-app-by-hexagod/index.md
@@ -15,7 +15,7 @@ sources:
  - [ 'twitter.com/bitchute/status/1321877439253934081', 'archive.is/RVmaj' ]
 ---
 
-[Google](/google/) removed a third-party [BitChute](/alttech/bitchute/) app (by
+Google removed a third-party [BitChute](/alttech/bitchute/) app (by
 a developer named _Hexagod_) from the Play Store claiming that it violated the
 "Webviews and Affiliate Spam Policy." The app had **220k installations** before
 it was removed.

--- a/website/content/events/google-voice-typing-censors-falun-gong-words/index.md
+++ b/website/content/events/google-voice-typing-censors-falun-gong-words/index.md
@@ -11,7 +11,7 @@ sources:
 ---
 
 Human rights activist Jennifer Zeng tweeted a video recorded by someone who was
-attempting to use [Google](/google/) Voice Typing for words and phrases related
+attempting to use Google Voice Typing for words and phrases related
 to Falun Gong, a spiritual practice [persecuted by the
 CCP](https://faluninfo.net/violent-suppression-of-100-million-people/) (Chinese
 Communist Party):

--- a/website/content/events/infowars-100k-bitchute-subs/index.md
+++ b/website/content/events/infowars-100k-bitchute-subs/index.md
@@ -21,4 +21,4 @@ speech video hosting platform.
 > -- BitChute (@bitchute) [19 Nov 2020](https://archive.is/RC0y5)
 
 Infowars [was banned](/e/alex-jones-mass-banned/) from
-[YouTube](/youtube/) over two years prior in August of 2018.
+YouTube over two years prior in August of 2018.

--- a/website/content/events/instagram-further-penalizes-dms/index.md
+++ b/website/content/events/instagram-further-penalizes-dms/index.md
@@ -8,7 +8,7 @@ sources:
  - [ 'Instagram "An update on our work to tackle abuse on Instagram" (10 Feb 2021)', 'archive.is/l7jJ6' ]
 ---
 
-[Instagram](/instagram/) announced that they would be [disabling the
+Instagram announced that they would be [disabling the
 accounts](https://archive.is/l7jJ6#selection-421.0-421.510) of users who "break
 the rules" in their direct (private) messages:
 

--- a/website/content/events/mailchimp-reserves-right-to-censor-inaccurate-content/index.md
+++ b/website/content/events/mailchimp-reserves-right-to-censor-inaccurate-content/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'Reclaim The Net "Mailchimp makes its censorship rules official, outlines right to ban users for “inaccurate” content" by Didi Rankovic (29 Oct 2020)', 'reclaimthenet.org/mailchimp-misinformation-censorship/' ]
 ---
 
-[Mailchimp](/mailchimp/) updated their approximately 6,200 word Terms of
+Mailchimp updated their approximately 6,200 word Terms of
 Service to include [the following gem](https://archive.is/spOEk#selection-2883.0-2883.230):
 
 > Mailchimp also does not allow the distribution of Content that is, in our

--- a/website/content/events/netflix-youtube-suppress-upperechelon-icarealot-review/index.md
+++ b/website/content/events/netflix-youtube-suppress-upperechelon-icarealot-review/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/UE_UpperEchelon/status/1367205639873830912', 'archive.is/xOQre' ]
 ---
 
-[YouTube](/youtube/) honored a copyright complaint manually filed by
+YouTube honored a copyright complaint manually filed by
 [Netflix](/netflix/) against a video published by _Upper Echelon Gaming_ that
 was a review of the recent Netflix movie _I Care A Lot_. The video simply
 played clips of the movie in the background without audio. YouTube suppressed

--- a/website/content/events/patreon-announces-qanon-purge/index.md
+++ b/website/content/events/patreon-announces-qanon-purge/index.md
@@ -9,7 +9,7 @@ sources:
 ---
 
 Two days after Media Matters published [an article](https://archive.is/fSkGj)
-criticizing [Patreon](/patreon/) for not banning QAnon related accounts,
+criticizing Patreon for not banning QAnon related accounts,
 Patreon announced [in a blog
 post](https://archive.is/LAzfQ#selection-365.0-365.571) that they would be
 removing accounts that spread "QAnon disinformation":

--- a/website/content/events/patreon-bans-inthematrixxx/index.md
+++ b/website/content/events/patreon-bans-inthematrixxx/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'patreon.com/inthematrixxx (archived removal notice)', 'archive.is/clAE4' ]
 ---
 
-[Patreon](/patreon/) banned [_InTheMatrixxx_](https://inthematrixxx.com/), an
+Patreon banned [_InTheMatrixxx_](https://inthematrixxx.com/), an
 independent media outlet, in an effort to purge QAnon-related accounts shortly
 after Media Matters published an article titled "Patreon is profiting from
 QAnon." The account had **369 patrons**.

--- a/website/content/events/patreon-bans-justinformed-talk/index.md
+++ b/website/content/events/patreon-bans-justinformed-talk/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'patreon.com/justinformedtalk (archived removal notice)', 'archive.is/644KC' ]
 ---
 
-[Patreon](/patreon/) banned [_JustInformed
+Patreon banned [_JustInformed
 Talk_](https://justinformednews.com/), a political satire and opinionated
 editorial review, in an effort to [purge QAnon-related](notice.png) accounts
 shortly after Media Matters published an article titled "Patreon is profiting

--- a/website/content/events/patreon-bans-patriots-soapbox/index.md
+++ b/website/content/events/patreon-bans-patriots-soapbox/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'graphtreon.com/creator/PatriotsSoapbox', 'archive.is/QIpnm' ]
 ---
 
-[Patreon](/patreon/) banned _Patriots' Soapbox News_ in an effort to purge
+Patreon banned _Patriots' Soapbox News_ in an effort to purge
 QAnon-related accounts shortly after Media Matters published an article titled
 "Patreon is profiting from QAnon." The account had **62 patrons**.
 

--- a/website/content/events/patreon-bans-patriots-soapbox/index.md
+++ b/website/content/events/patreon-bans-patriots-soapbox/index.md
@@ -28,4 +28,4 @@ QAnon-related accounts shortly after Media Matters published an article titled
 > -- NotPSB (@NotPsb) [22 Oct 2020](https://archive.is/vzQgy)
 
 _Patriots' Soapbox_ [was banned](/e/youtube-bans-patriots-soapbox/) from
-[YouTube](/youtube/) one week prior.
+YouTube one week prior.

--- a/website/content/events/patreon-bans-sgtreport/index.md
+++ b/website/content/events/patreon-bans-sgtreport/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'twitter.com/SGTreport/status/1319363047669059587', 'archive.is/EZyPT' ]
 ---
 
-[Patreon](/patreon/) banned _SGTreport_ in an effort to purge QAnon-related
+Patreon banned _SGTreport_ in an effort to purge QAnon-related
 accounts shortly after Media Matters published an article titled "Patreon is
 profiting from QAnon." The account had over **1k patrons**.
 

--- a/website/content/events/patreon-bans-tlav/index.md
+++ b/website/content/events/patreon-bans-tlav/index.md
@@ -16,7 +16,7 @@ sources:
  - [ 'Archive of page removed (patreon.com/TheLastAmericanVagabond)', 'archive.is/vS6CO' ]
 ---
 
-[Patreon](/patreon/) banned _The Last American Vagabond_ for "spreading medical
+Patreon banned _The Last American Vagabond_ for "spreading medical
 misinformation" about a week after Patreon's "Trust & Safety" team threatened
 him with account removal unless all of the "medical misinformation" content was
 removed. Patreon only gave one examle of such violative content, but that

--- a/website/content/events/patreon-bans-trureporting/index.md
+++ b/website/content/events/patreon-bans-trureporting/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'patreon.com/TRUreporting (archived page removed)', 'archive.is/ZeTtK' ]
 ---
 
-[Patreon](/patreon/) banned _TRUreporting_ (one week after they were [banned
+Patreon banned _TRUreporting_ (one week after they were [banned
 from YouTube](/e/youtube-bans-trureporting/)) in an effort to remove
 accounts containing QAnon content. The two and a half year old account had
 **334 patrons**.

--- a/website/content/events/patreon-bans-woke-societies/index.md
+++ b/website/content/events/patreon-bans-woke-societies/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'patreon.com/wokesocieties1111 (archived page removed)', 'archive.is/iSldz' ]
 ---
 
-[Patreon](/patreon/) banned _Woke Societies_ in an effort to [purge
+Patreon banned _Woke Societies_ in an effort to [purge
 QAnon-related](notice.jpg) accounts shortly after Media Matters published an
 article titled "Patreon is profiting from QAnon." The account had over **236
 patrons**.

--- a/website/content/events/project-veritas-facebook-content-moderation/index.md
+++ b/website/content/events/project-veritas-facebook-content-moderation/index.md
@@ -14,7 +14,7 @@ sources:
 ---
 
 Project Veritas released a report on their insider investigation into
-[Facebook](/facebook/)'s political content moderation practices in regards to
+Facebook's political content moderation practices in regards to
 the upcoming election. One of the main takeaways, as Facebook insider Zach
 McElroy said, is that Facebook is "essentially in charge of what gets said and
 what gets stifled", which is illustrated by the following [excerpt from the

--- a/website/content/events/signal-telegram-see-accelerated-growth/index.md
+++ b/website/content/events/signal-telegram-see-accelerated-growth/index.md
@@ -19,7 +19,7 @@ extra:
  - [ 'twitter.com/signalapp/status/1348079223701794819', 'archive.is/RPLW2' ]
 ---
 
-In an update to their Terms of Service, the [Facebook](/facebook/) owned
+In an update to their Terms of Service, the Facebook owned
 messenging app WhatsApp announced that they would be requiring users to consent
 to having their data and information shared with Facebook. As [Engadget
 reported](https://archive.is/bYPHF#selection-1489.0-1493.163):

--- a/website/content/events/twitch-shoutout-sub-refund-option/index.md
+++ b/website/content/events/twitch-shoutout-sub-refund-option/index.md
@@ -12,7 +12,7 @@ sources:
 ---
 
 [Twitch](/twitch/) is an online streaming platform, owned by
-[Amazon](/amazon/), where users can "subscribe" to their favorite streamers by
+Amazon, where users can "subscribe" to their favorite streamers by
 paying a monthly subscription fee in exchange for various perks. Typically when
 someone subscribes, the streamer will thank that person on stream. Twitch
 offers users the ability to terminate their subscription and refund them the

--- a/website/content/events/twitter-bans-carey-wedler/index.md
+++ b/website/content/events/twitter-bans-carey-wedler/index.md
@@ -14,7 +14,7 @@ extra:
  - [ 'YouTube "The REAL reason for the coming wave of bans and censorship: what you aren''t being told" by Carey Wedler (19 Sep 2018)', 'www.youtube.com/watch?v=xN8k22F1Wfw' ]
 ---
 
-[Twitter](/twitter/) permanently banned Carey Wedler (@CareyWedler) for no
+Twitter permanently banned Carey Wedler (@CareyWedler) for no
 reason on the same day that _The Anti-Media_ (the outlet where she served as
 editor-in-chief) was [banned by both Facebook and
 Twitter](/e/facebook-twitter-ban-antimedia/). Her nine year old account

--- a/website/content/events/twitter-bans-gatewaypundit/index.md
+++ b/website/content/events/twitter-bans-gatewaypundit/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'twitter.com/joshdcaplan/status/1358196234897530881', 'archive.is/qvsBz' ]
 ---
 
-[Twitter](/twitter/) banned Jim Hoft, founder of the Gateway Pundit, for
+Twitter banned Jim Hoft, founder of the Gateway Pundit, for
 violating their "Civic Integrity Policy" shortly after he published [an
 article](https://archive.is/ehruB) titled _Exclusive: The TCF Center Election
 Fraud – Newly Discovered Video Shows Late Night Deliveries of Tens of Thousands

--- a/website/content/events/twitter-bans-laura-loomer/index.md
+++ b/website/content/events/twitter-bans-laura-loomer/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'RT "Twitter bans right-wing conspiracist Laura Loomer, renewing free speech debate" (22 Nov 2020)', 'archive.is/9sQaU' ]
 ---
 
-[Twitter](/twitter/) banned journalist Laura Loomer for a tweet criticizing
+Twitter banned journalist Laura Loomer for a tweet criticizing
 Ilhan Omar, a US congresswoman. The account had about 265k followers at the
 time. The offending tweet was the following:
 

--- a/website/content/events/twitter-bans-memelord-dailydigger19/index.md
+++ b/website/content/events/twitter-bans-memelord-dailydigger19/index.md
@@ -16,7 +16,7 @@ sources:
  - [ 'OnlyBans "MemeLord (@dailydigger19) Banned From Twitter" (18 Oct 2020)', 'archive.is/bK69Q' ]
 ---
 
-[Twitter](/twitter/) banned _Memelord_ (@dailydigger19) likely as part of their
+Twitter banned _Memelord_ (@dailydigger19) likely as part of their
 efforts to [suppress the Hunter Biden laptop scandal](/t/hunters-laptop/) since
 all of this account's tweets just prior to being banned are about the laptop
 and the censorship surrounding it. The account, along with many others, even

--- a/website/content/events/twitter-bans-mike-lindell/index.md
+++ b/website/content/events/twitter-bans-mike-lindell/index.md
@@ -16,7 +16,7 @@ extra:
  - [ '', 'archive.is/wip/r6LyA' ]
 ---
 
-[Twitter](/twitter/) banned Mike Lindell (**@realMikeLindell**), the CEO of My
+Twitter banned Mike Lindell (**@realMikeLindell**), the CEO of My
 Pillow, for violating Twitter's Civic Integrity Policy by spreading "election
 misinformation." Lindell [told the
 StarTribune](https://archive.is/py6Ob#selection-1949.0-1949.168) that he had

--- a/website/content/events/twitter-bans-press-for-truth/index.md
+++ b/website/content/events/twitter-bans-press-for-truth/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'Archive of profile page removal', 'archive.is/RaOCU' ]
 ---
 
-[Twitter](/twitter/) banned _Press For Truth_ (@PressForTruth), an independent
+Twitter banned _Press For Truth_ (@PressForTruth), an independent
 media outlet run by journalist Dan Dicks, [for violating Twitter's
 rules](notice.jpg) against "platform manipulation and spam." The eight year old
 account had over **20k followers**.

--- a/website/content/events/twitter-bans-project-veritas-suspends-okeefe/index.md
+++ b/website/content/events/twitter-bans-project-veritas-suspends-okeefe/index.md
@@ -20,7 +20,7 @@ extra:
  - [ 'Styxhexenhammer666 "Twitter Deplatforms Project Veritas, Because They Are Afraid of Them (Bitchute Exclusive)" on BitChute (14 Feb 2021)', 'www.bitchute.com/video/MLKWVPTmeaXl/' ]
 ---
 
-[Twitter](/twitter/) permanently banned Project Veritas and temporarily
+Twitter permanently banned Project Veritas and temporarily
 suspended its founder, James O'Keefe, for violating the policies against
 "posting private information." This happened after Project Veritas published a
 video of one of their journalists confronting the VP of Facebook in front of

--- a/website/content/events/twitter-bans-redpill78/index.md
+++ b/website/content/events/twitter-bans-redpill78/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'Archive of profile page removal', 'archive.is/c3iDa' ]
 ---
 
-[Twitter](/twitter/) banned _RedPill78_, an independent journalist, about a
+Twitter banned _RedPill78_, an independent journalist, about a
 week after they were [banned from YouTube](/e/youtube-bans-redpill78/).
 The ten year old account had over **158k followers**.
 

--- a/website/content/events/twitter-bans-steve-bannons-war-room/index.md
+++ b/website/content/events/twitter-bans-steve-bannons-war-room/index.md
@@ -14,7 +14,7 @@ extra:
  - [ '', 'twitter.com/FrankFigliuzzi1/status/1324485819042705408' ]
 ---
 
-[Twitter](/twitter/) permanently banned _Steve Bannon's War Room_ after he made
+Twitter permanently banned _Steve Bannon's War Room_ after he made
 the following comments during one of the War Room's podcasts:
 
 > Second term kicks off with firing Wray, firing Fauci. Nah, actually I wanna

--- a/website/content/events/twitter-bans-technofog/index.md
+++ b/website/content/events/twitter-bans-technofog/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'twitter.com/Techno_Fog/status/1349575367762317317', 'archive.is/a41t9' ]
 ---
 
-[Twitter](/twitter/) banned **@Techno_fog**, a lawyer who provides dry and
+Twitter banned **@Techno_fog**, a lawyer who provides dry and
 factual political commentary and updates, for violating the Twitter Rules
 against "platform manipulation and spam."
 

--- a/website/content/events/twitter-bans-trump/index.md
+++ b/website/content/events/twitter-bans-trump/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'twitter.com/therecount/status/1359505558814998531', 'archive.is/NAYTq' ]
 ---
 
-[Twitter](/twitter/) permanmently banned President Trump shortly after [his 12
+Twitter permanmently banned President Trump shortly after [his 12
 hour suspension](/e/twitter-facebook-suspend-trump/) was lifted. Right
 after his personal account was banned, he issued the following statement from
 the @POTUS account, causing that account to be removed as well.

--- a/website/content/events/twitter-facebook-purge-peacedata/index.md
+++ b/website/content/events/twitter-facebook-purge-peacedata/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'Some archives of the site', 'archive.is/https://peacedata.net/' ]
 ---
 
-[Twitter](/twitter/) and [Facebook](/facebook/) purged accounts and pages
+Twitter and [Facebook](/facebook/) purged accounts and pages
 related to _PeaceData_, a website that was allegedly a Russian-backed
 "information campaign." Twitter and Facebook both took these enforcement
 actions based on information they received from the United States FBI (Federal

--- a/website/content/events/twitter-facebook-purge-peacedata/index.md
+++ b/website/content/events/twitter-facebook-purge-peacedata/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'Some archives of the site', 'archive.is/https://peacedata.net/' ]
 ---
 
-Twitter and [Facebook](/facebook/) purged accounts and pages
+Twitter and Facebook purged accounts and pages
 related to _PeaceData_, a website that was allegedly a Russian-backed
 "information campaign." Twitter and Facebook both took these enforcement
 actions based on information they received from the United States FBI (Federal

--- a/website/content/events/twitter-facebook-suspend-trump/index.md
+++ b/website/content/events/twitter-facebook-suspend-trump/index.md
@@ -17,7 +17,7 @@ extra:
 ---
 
 Shortly after the rioting in the US capitol on Jan 6, 2020,
-Twitter and [Facebook](/facebook/) took several drastic actions
+Twitter and Facebook took several drastic actions
 including suspending the President himself.
 
 Twitter removed three of Trump's tweets (including ones that told the rioters

--- a/website/content/events/twitter-facebook-suspend-trump/index.md
+++ b/website/content/events/twitter-facebook-suspend-trump/index.md
@@ -17,7 +17,7 @@ extra:
 ---
 
 Shortly after the rioting in the US capitol on Jan 6, 2020,
-[Twitter](/twitter/) and [Facebook](/facebook/) took several drastic actions
+Twitter and [Facebook](/facebook/) took several drastic actions
 including suspending the President himself.
 
 Twitter removed three of Trump's tweets (including ones that told the rioters

--- a/website/content/events/twitter-misleading-vaccine-information/index.md
+++ b/website/content/events/twitter-misleading-vaccine-information/index.md
@@ -8,7 +8,7 @@ sources:
  - [ 'Twitter Blog "COVID-19: Our approach to misleading vaccine information" by Twitter Safety (16 Dec 2020)', 'archive.is/wnYXB' ]
 ---
 
-[Twitter](/twitter/) announced in a blog post that they would be removing
+Twitter announced in a blog post that they would be removing
 tweets that contain "harmful false or misleading information" about COVID-19
 vaccines and labeling tweets that "advance unsubstantiated rumors." [From the
 announcement](https://archive.is/wnYXB#selection-763.0-803.166):

--- a/website/content/events/twitter-prevents-liking-replying-trump-tweets/index.md
+++ b/website/content/events/twitter-prevents-liking-replying-trump-tweets/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'twitter.com/bennyjohnson/status/1337804092643676161', 'archive.is/5vgl3' ]
 ---
 
-[Twitter](/twitter/) disabled the ability to like or reply to several of
+Twitter disabled the ability to like or reply to several of
 President Trump's tweets as he was ranting about the Supreme Court, Attorney
 General Bill Barr, and the Republican establishment. A few hours later, Twitter
 re-enabled the ability to like and reply to the tweets in question while

--- a/website/content/events/twitter-removes-accounts-undermine-faith-in-nato/index.md
+++ b/website/content/events/twitter-removes-accounts-undermine-faith-in-nato/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'The Grayzone "‘No one cares if we die’: Ex-Syrian rebels recount Nagorno-Karabakh nightmare as ‘disposable force for Turkey’" by Lindsey Snell (26 Feb 2021)', 'archive.is/VcZOg' ]
 ---
 
-[Twitter](/twitter/) announced the [permanent removal of 373 "state-affiliated"
+Twitter announced the [permanent removal of 373 "state-affiliated"
 accounts](https://archive.is/NdkNb#selection-589.87-593.10) that they
 attributed to Armenia, Russia and Iran:
 

--- a/website/content/events/twitter-removes-iranian-accounts-tip-from-fbi/index.md
+++ b/website/content/events/twitter-removes-iranian-accounts-tip-from-fbi/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'ZDNet "Twitter removes 130 Iranian accounts for trying to disrupt the US Presidential Debate" by Catalin Cimpanu (1 Oct 2020)', 'archive.is/2o2q7' ]
 ---
 
-[Twitter](/twitter/) announced the removal of 130 accounts that they said
+Twitter announced the removal of 130 accounts that they said
 "appeared" to be Iranian and that were trying to **"disrupt the public
 conversation during the first 2020 US Presidential Debate."** Twitter did this
 based on a lead from the FBI.

--- a/website/content/events/twitter-removes-several-far-left-accounts/index.md
+++ b/website/content/events/twitter-removes-several-far-left-accounts/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'twitter.com/ByMikeBaker/status/1352037060421402629', 'archive.is/kQJJE' ]
 ---
 
-[Twitter](/twitter/) banned several far left / Antifa accounts the day after
+Twitter banned several far left / Antifa accounts the day after
 far left groups protested Biden's inauguration and attacked the Democratic
 Party headquarters in Portland, Oregon.
 

--- a/website/content/events/twitter-restricts-vote-mobile-tweets-suspends-cassandra-fairbanks/index.md
+++ b/website/content/events/twitter-restricts-vote-mobile-tweets-suspends-cassandra-fairbanks/index.md
@@ -31,7 +31,7 @@ Deadline_. Fairbanks tweeted a link to the article with the following text:
 >
 >  -- Cassandra Fairbanks (@CassandraRules) [5 Feb 2021](https://archive.is/TeegJ)
 
-[Twitter](/twitter/) almost immediately restricted that tweet (meaning no one
+Twitter almost immediately restricted that tweet (meaning no one
 could like, retweet, or reply to it) as well as placed a warning on it that
 read **"This claim of election fraud is disputed, and this Tweet can’t be
 replied to, Retweeted, or liked due to a risk of violence."** While the article

--- a/website/content/events/twitter-suspends-steve-bannons-war-room/index.md
+++ b/website/content/events/twitter-suspends-steve-bannons-war-room/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/WarRoomPandemic/status/1323988779875655681', 'archive.is/txxF9' ]
 ---
 
-[Twitter](/twitter/) temporarily suspended the account of _Steve Bannon's War
+Twitter temporarily suspended the account of _Steve Bannon's War
 Room_ for 12 hours on the night of the US 2020 Presidential Election. [The
 reason](notice.jpg) was simply "violating the Twitter Rules."
 

--- a/website/content/events/x22report-100k-bitchute-subs/index.md
+++ b/website/content/events/x22report-100k-bitchute-subs/index.md
@@ -12,7 +12,7 @@ sources:
 
 [_X22report_](/profiles/x22report/) became the 3rd channel to reach **100k
 subscribers** on [BitChute](/alttech/bitchute/), a video hosting platform
-similar to [YouTube](/youtube/).
+similar to YouTube.
 
 > Congratulations to @X22Report for reaching 100,000 subscribers! The 3rd
 > channel to do so 🏆 🚀

--- a/website/content/events/youtube-bans-alice-down-the-rabbit-hole/index.md
+++ b/website/content/events/youtube-bans-alice-down-the-rabbit-hole/index.md
@@ -15,7 +15,7 @@ youtube:
  videos: 294
 ---
 
-[YouTube](/youtube/) banned [_Alice Down the Rabbit
+YouTube banned [_Alice Down the Rabbit
 Hole_](https://www.bitchute.com/channel/uwiaOStnHXwB/), a political commentary
 channel, in an attempt to purge channels that the platform claimed were
 spreading "harmful conspiracy theories." The year and a half old channel had

--- a/website/content/events/youtube-bans-amazing-polly/index.md
+++ b/website/content/events/youtube-bans-amazing-polly/index.md
@@ -12,7 +12,7 @@ sources:
  - [ 'BitChute "Truth Purge - Youtube Got Rid of Me" by Amazing Polly (15 Oct 2020)', 'www.bitchute.com/video/kr0UZsQVZ8AC/' ]
 ---
 
-[YouTube](/youtube/) banned _Amazing Polly_ in an effort to purge channels that
+YouTube banned _Amazing Polly_ in an effort to purge channels that
 the platform claimed were spreading "harmful conspiracy theories." The four and
 a half year old channel had nearly **376k subscribers** and over **24.5 million
 total views**.

--- a/website/content/events/youtube-bans-anna-brees/index.md
+++ b/website/content/events/youtube-bans-anna-brees/index.md
@@ -21,7 +21,7 @@ youtube:
  videos: 444
 ---
 
-[YouTube](/youtube/) banned Anna Brees, an independent journalist, due to a
+YouTube banned Anna Brees, an independent journalist, due to a
 video that was published three months prior which violated YouTube's policy on
 not contradicting health "authorities." The video (still available [on
 BitChute](https://www.bitchute.com/video/lRJt4Cw4lC8/)) is simply Brees

--- a/website/content/events/youtube-bans-blessed-to-teach/index.md
+++ b/website/content/events/youtube-bans-blessed-to-teach/index.md
@@ -16,7 +16,7 @@ youtube:
  videos: 785
 ---
 
-[YouTube](/youtube/) banned [_Blessed To
+YouTube banned [_Blessed To
 Teach_](https://blessed2teach.com/about/), a Christian news channel, in an
 attempt to purge channels that the platform claimed were spreading "harmful
 conspiracy theories." The five year old channel had about **109k subscribers**

--- a/website/content/events/youtube-bans-dave-cullen/index.md
+++ b/website/content/events/youtube-bans-dave-cullen/index.md
@@ -21,7 +21,7 @@ youtube:
  videos: 1812
 ---
 
-[YouTube](/youtube/) banned Dave Cullen of _Computing Forever_ after issuing
+YouTube banned Dave Cullen of _Computing Forever_ after issuing
 his channel its [third and final strike](https://archive.is/vvexd) for a video
 that was published three months prior. The video, titled _This is a Spiritual
 Battle_, is still available [on

--- a/website/content/events/youtube-bans-dollar-vigilante/index.md
+++ b/website/content/events/youtube-bans-dollar-vigilante/index.md
@@ -19,7 +19,7 @@ youtube:
  videos: 1003
 ---
 
-[YouTube](/youtube/) banned _The Dollar Vigilante_, a financial newsletter and
+YouTube banned _The Dollar Vigilante_, a financial newsletter and
 political commentary channel, after they were issued a third strike within a 90
 day period. The third strike was for violating YouTube's "medical
 misinformation policy." The channel had over **304k subscribers** and more than

--- a/website/content/events/youtube-bans-global-watchmen-news/index.md
+++ b/website/content/events/youtube-bans-global-watchmen-news/index.md
@@ -15,7 +15,7 @@ youtube:
  videos: 461
 ---
 
-[YouTube](/youtube/) banned _Global Watchmen News_, an alternative news
+YouTube banned _Global Watchmen News_, an alternative news
 channel, in an attempt to purge channels that the platform claimed were
 spreading "harmful conspiracy theories." The five year old channel had about
 **30.9k subscribers** and over **3 million total views** across 461 videos.

--- a/website/content/events/youtube-bans-in-pursuit-of-truth/index.md
+++ b/website/content/events/youtube-bans-in-pursuit-of-truth/index.md
@@ -17,7 +17,7 @@ youtube:
  videos: 619
 ---
 
-[YouTube](/youtube/) banned [_In Pursuit of Truth
+YouTube banned [_In Pursuit of Truth
 (IPOT)_](https://www.bitchute.com/channel/Xe2ztraIRXRX/), a political
 commentary channel, in an attempt to purge channels that the platform claimed
 were spreading "harmful conspiracy theories." The two and a half year old

--- a/website/content/events/youtube-bans-inthematrixxx/index.md
+++ b/website/content/events/youtube-bans-inthematrixxx/index.md
@@ -14,7 +14,7 @@ youtube:
  videos: 464
 ---
 
-[YouTube](/youtube/) banned [_InTheMatrixxx_](https://inthematrixxx.com/), an
+YouTube banned [_InTheMatrixxx_](https://inthematrixxx.com/), an
 independent media outlet, in an attempt to purge channels that the platform
 claimed were spreading "harmful conspiracy theories." The seven year old
 channel had about **77k subscribers** and over **4.6 million total views**

--- a/website/content/events/youtube-bans-jason-liosatos/index.md
+++ b/website/content/events/youtube-bans-jason-liosatos/index.md
@@ -12,7 +12,7 @@ extra:
  - [ 'twitter.com/JasonLiosatos/status/1350177444746158084', 'archive.is/oZiS9' ]
 ---
 
-[YouTube](/youtube/) banned [Jason Liosatos](https://jasonliosatos.com/), an
+YouTube banned [Jason Liosatos](https://jasonliosatos.com/), an
 author, artist and host of a weekly show called _Outside the Box_ where he has
 been an outspoken critic of lockdowns, mandatory vaccines and censorship. His
 11 year old channel had **20,700 subscribers** and **over 1.8 million total

--- a/website/content/events/youtube-bans-justinformed-talk/index.md
+++ b/website/content/events/youtube-bans-justinformed-talk/index.md
@@ -15,7 +15,7 @@ youtube:
  videos: 890
 ---
 
-[YouTube](/youtube/) permanently banned [_JustInformed
+YouTube permanently banned [_JustInformed
 Talk_](https://justinformednews.com/), a political satire and opinionated
 editorial review, in an attempt to purge channels that the platform claimed
 were spreading "harmful conspiracy theories." The five and a half year old

--- a/website/content/events/youtube-bans-know-more-news/index.md
+++ b/website/content/events/youtube-bans-know-more-news/index.md
@@ -19,7 +19,7 @@ youtube:
  videos: 569
 ---
 
-[YouTube](/youtube/) banned [_Know More
+YouTube banned [_Know More
 News_,](https://www.knowmorenews.org/about-me) an independent media channel run
 by journalist Adam Green. No specific reason was given [other than](notice.png)
 "a violation of YouTube's Terms of Service." The six year old channel had over

--- a/website/content/events/youtube-bans-mark-taylor/index.md
+++ b/website/content/events/youtube-bans-mark-taylor/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/patton6966/status/1317132892695334912', 'archive.is/gAAm1' ]
 ---
 
-[YouTube](/youtube/) banned [Mark Taylor](https://sordrescue.com/) in an effort
+YouTube banned [Mark Taylor](https://sordrescue.com/) in an effort
 to purge channels that the platform claimed were spreading "harmful conspiracy
 theories." The two year old channel had **109k subscribers** and **4.6 million
 total views**.

--- a/website/content/events/youtube-bans-mouthy-buddha/index.md
+++ b/website/content/events/youtube-bans-mouthy-buddha/index.md
@@ -17,7 +17,7 @@ youtube:
  videos: 90
 ---
 
-[YouTube](/youtube/) banned [_Mouthy
+YouTube banned [_Mouthy
 Buddha_](https://www.bitchute.com/channel/wnuZEpMvRZs6/), a political content
 creator, in an attempt to purge channels that the platform claimed were
 spreading "harmful conspiracy theories." The year and a half old channel had

--- a/website/content/events/youtube-bans-patriots-soapbox/index.md
+++ b/website/content/events/youtube-bans-patriots-soapbox/index.md
@@ -16,7 +16,7 @@ youtube:
  views: 21810131
 ---
 
-[YouTube](/youtube/) deleted the channel _Patriots' Soapbox News Network LIVE_
+YouTube deleted the channel _Patriots' Soapbox News Network LIVE_
 in an effort to purge channels that the platform claimed were spreading
 "harmful conspiracy theories." The two and a half year old channel had **80k
 subscribers** and nearly **22 million total views**.

--- a/website/content/events/youtube-bans-patriots-soapbox/index.md
+++ b/website/content/events/youtube-bans-patriots-soapbox/index.md
@@ -32,4 +32,4 @@ subscribers** and nearly **22 million total views**.
 > -- NotPSB (@NotPsb) [15 Oct 2020](https://archive.is/XNBM9)
 
 _Patriots' Soapbox_ [was banned](/e/patreon-bans-patriots-soapbox/) from
-[Patreon](/patreon/) one week later.
+Patreon one week later.

--- a/website/content/events/youtube-bans-press-for-truth/index.md
+++ b/website/content/events/youtube-bans-press-for-truth/index.md
@@ -19,7 +19,7 @@ extra:
  - [ '', 'odysee.com/@PressForTruth:4/PFT-Terminated-VIDEO:a' ]
 ---
 
-[YouTube](/youtube/) "permanently disabled" _Press For Truth_, an independent
+YouTube "permanently disabled" _Press For Truth_, an independent
 media channel run by Dan Dicks. His **14 year old channel** had about **272k
 subscribers** and over **35 million lifetime views**, and it was removed
 without any warning, guidelines strike, or explanation.

--- a/website/content/events/youtube-bans-redpill78/index.md
+++ b/website/content/events/youtube-bans-redpill78/index.md
@@ -21,7 +21,7 @@ youtube:
  videos: 797
 ---
 
-[YouTube](/youtube/) banned _RedPill78_ in an attempt to purge channels that
+YouTube banned _RedPill78_ in an attempt to purge channels that
 the platform claimed were spreading "harmful conspiracy theories." The 14 year
 old channel had over **270k subscribers** and nearly **49 million total views**
 across almost 800 videos.

--- a/website/content/events/youtube-bans-spaceshot76/index.md
+++ b/website/content/events/youtube-bans-spaceshot76/index.md
@@ -17,7 +17,7 @@ youtube:
  videos: 791
 ---
 
-[YouTube](/youtube/) banned [_Spaceshot76_](/profiles/spaceshot76/), a
+YouTube banned [_Spaceshot76_](/profiles/spaceshot76/), a
 political content creator, in an attempt to purge channels that the platform
 claimed were spreading "harmful conspiracy theories." The year and a half old
 channel had about **160k subscribers** and over **32.2 million total views**

--- a/website/content/events/youtube-bans-the-conscious-resistance/index.md
+++ b/website/content/events/youtube-bans-the-conscious-resistance/index.md
@@ -20,7 +20,7 @@ youtube:
  videos: 1820
 ---
 
-[YouTube](/youtube/) banned _The Conscious Resistance Network_ after the
+YouTube banned _The Conscious Resistance Network_ after the
 channel received a third strike [due to](notice.png) violating the platform's
 "sale of regulated goods policy." The seven year old channel had over **64k
 subscribers** and more than **5 million total views** across 1820 videos.

--- a/website/content/events/youtube-bans-the-last-american-vagabond/index.md
+++ b/website/content/events/youtube-bans-the-last-american-vagabond/index.md
@@ -35,7 +35,7 @@ The seven and a half year old channel had nearly **103k subscribers** and over
 > -- LastAmericanVagabond (@TLAVagabond) [19 Oct 2020](https://archive.is/gMfyZ)
 
 _The Last American Vagabond_ pushed back when YouTube attempted their usual,
-two-faced customer service a couple days later on [Twitter](/twitter/), saying
+two-faced customer service a couple days later on Twitter, saying
 they were "Sorry to hear about the trouble" and that he could contact them if
 he thought his channel "was terminated by mistake."
 

--- a/website/content/events/youtube-bans-the-last-american-vagabond/index.md
+++ b/website/content/events/youtube-bans-the-last-american-vagabond/index.md
@@ -22,7 +22,7 @@ youtube:
  videos: 2040
 ---
 
-[YouTube](/youtube/) banned _The Last American Vagabond_ during a live stream.
+YouTube banned _The Last American Vagabond_ during a live stream.
 The seven and a half year old channel had nearly **103k subscribers** and over
 **14.5 million total views** across more than 2,000 videos.
 

--- a/website/content/events/youtube-bans-the-patriot-hour/index.md
+++ b/website/content/events/youtube-bans-the-patriot-hour/index.md
@@ -15,7 +15,7 @@ youtube:
  videos: 2051
 ---
 
-[YouTube](/youtube/) banned [_The Patriot Hour_](https://thepatriothour.com/),
+YouTube banned [_The Patriot Hour_](https://thepatriothour.com/),
 a political commentary channel, in an attempt to purge channels that the
 platform claimed were spreading "harmful conspiracy theories." The two and a
 half year old channel had about **249k subscribers** and over **54.3 million

--- a/website/content/events/youtube-bans-titus-frost/index.md
+++ b/website/content/events/youtube-bans-titus-frost/index.md
@@ -21,7 +21,7 @@ youtube:
  videos: 752
 ---
 
-[YouTube](/youtube/) banned [_Titus
+YouTube banned [_Titus
 Frost_](https://www.bitchute.com/channel/2Zo51w9MJ8db/), a political content
 creator, in an attempt to purge channels that the platform claimed were
 spreading "harmful conspiracy theories." The five year old channel had about

--- a/website/content/events/youtube-bans-trump/index.md
+++ b/website/content/events/youtube-bans-trump/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'Summit News "YouTube Suspends Trump" by Steve Watson (13 Jan 2021)', 'summit.news/2021/01/13/youtube-suspends-trump/' ]
 ---
 
-[YouTube](/youtube/) removed some videos from President Trump's channel and
+YouTube removed some videos from President Trump's channel and
 then permanently banned him without giving a specific reason or citing specific
 content.
 

--- a/website/content/events/youtube-bans-trureporting/index.md
+++ b/website/content/events/youtube-bans-trureporting/index.md
@@ -22,7 +22,7 @@ youtube:
  videos: 864
 ---
 
-[YouTube](/youtube/) banned _TRUreporting_ in an attempt to purge channels that
+YouTube banned _TRUreporting_ in an attempt to purge channels that
 the platform claimed were spreading "harmful conspiracy theories." The 15 year
 old channel had nearly **217k subscribers** and over **23.5 million total
 views** across almost 900 videos.

--- a/website/content/events/youtube-bans-woke-societies/index.md
+++ b/website/content/events/youtube-bans-woke-societies/index.md
@@ -15,7 +15,7 @@ sources:
  - [ 'youtube.com/channel/UCChqaZ_kStPhOgDx1NxdA0w', 'archive.is/1Oa5R/image' ]
 ---
 
-[YouTube](/youtube/) banned _Woke Societies_ in an attempt to purge channels
+YouTube banned _Woke Societies_ in an attempt to purge channels
 that the platform claimed were spreading "harmful conspiracy theories." The
 year and a half old channel had about **108k subscribers** and over **4.5
 million total views** across 192 videos.

--- a/website/content/events/youtube-bans-world-alternative-media/index.md
+++ b/website/content/events/youtube-bans-world-alternative-media/index.md
@@ -28,7 +28,7 @@ youtube:
  videos: 1705
 ---
 
-[YouTube](/youtube/) banned _World Alternative Media_ in an attempt to purge
+YouTube banned _World Alternative Media_ in an attempt to purge
 channels that the platform claimed were spreading "harmful conspiracy
 theories." The seven and a half year old channel had over **154k subscribers**
 and more than **21.5 million total views** across 1700 videos.

--- a/website/content/events/youtube-demonetizes-cyberdemon531/index.md
+++ b/website/content/events/youtube-demonetizes-cyberdemon531/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'YouTube "UPDATE: What YouTube Demonetization Means And How You Can Help Me" by Cyberdemon531 (4 Feb 2021)', 'www.youtube.com/watch?v=jR6suSK912Y' ]
 ---
 
-[YouTube](/youtube/) demonetized _CyberDemon531_, an anarcho-communist who
+YouTube demonetized _CyberDemon531_, an anarcho-communist who
 hosts a show called _Above It All_. YouTube did not provide specific examples
 of which content caused this.
 

--- a/website/content/events/youtube-demonetizes-franc-analysis/index.md
+++ b/website/content/events/youtube-demonetizes-franc-analysis/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'twitter.com/B43Franco/status/1357123993476726785', 'archive.is/ClZzE' ]
 ---
 
-[YouTube](/youtube/) demonetized _Franc Analysis_, a progressive political talk
+YouTube demonetized _Franc Analysis_, a progressive political talk
 show, even though the channel wasn't even monetized to begin with.
 
 > I haven't even been monetized for 2 months and @YouTube just demonetized me.

--- a/website/content/events/youtube-demonetizes-graham-elwood/index.md
+++ b/website/content/events/youtube-demonetizes-graham-elwood/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'twitter.com/grahamelwood/status/1356152540711301120', 'archive.is/iVo2s' ]
 ---
 
-[YouTube](/youtube/) demonetized Graham Elwood's channel, a stand-up comic and
+YouTube demonetized Graham Elwood's channel, a stand-up comic and
 progressive political commentator. The video he published the day prior was
 titled _JFK Assassination Part 2, Wall Street Turned Upside Down, & Oil
 Subsidies - Gov't Secrets Ep. 027_.

--- a/website/content/events/youtube-demonetizes-jennifer-zeng/index.md
+++ b/website/content/events/youtube-demonetizes-jennifer-zeng/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'Reclaim The Net "YouTube strips human rights activist Jennifer Zeng of income" by Didi Rankovic (8 May 2020)', 'reclaimthenet.org/jennifer-zeng-demonetized/' ]
 ---
 
-[YouTube](/youtube/) demonetized _Inconvenient Truths by Jennifer Zeng_, a
+YouTube demonetized _Inconvenient Truths by Jennifer Zeng_, a
 Chinese dissident and human rights activist, after she published a video titled
 _Origin of the CCP Virus: The Missing Piece of the Puzzle_. While YouTube did
 not give Zeng a specifc reason or explanation (rather just [a one sentence

--- a/website/content/events/youtube-demonetizes-niko-house/index.md
+++ b/website/content/events/youtube-demonetizes-niko-house/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'twitter.com/nikoCSFB/status/1357544988872224770', 'archive.is/E4xcQ' ]
 ---
 
-[YouTube](/youtube/) demonetized Niko House, a progressive political
+YouTube demonetized Niko House, a progressive political
 commentator and host of a show called _Mi Casa Es Su Casa_.
 
 > Guess who got his channel demonetized by YouTube w/ no explanation as to what

--- a/website/content/events/youtube-demonetizes-the-convo-couch/index.md
+++ b/website/content/events/youtube-demonetizes-the-convo-couch/index.md
@@ -8,7 +8,7 @@ sources:
  - [ 'twitter.com/Fiorella_im/status/1357061435600244736', 'archive.is/cTx25' ]
 ---
 
-[YouTube](/youtube/) demonetized _The Convo Couch_, a progressive political
+YouTube demonetized _The Convo Couch_, a progressive political
 show hosted by Fiorella Isabel. YouTube only gave [a vague
 explanation](notice.jpg) of "harmful content" and did not cite specific
 guideline violations.

--- a/website/content/events/youtube-demonetizes-the-epoch-times/index.md
+++ b/website/content/events/youtube-demonetizes-the-epoch-times/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'Breitbart "YouTube Demonetizes the Epoch Times" by Allum Bokhari (27 Jan 2021)', 'archive.is/N8N6L' ]
 ---
 
-[YouTube](/youtube/) demonetized _The Epoch Times_, an independent news outlet.
+YouTube demonetized _The Epoch Times_, an independent news outlet.
 While YouTube did not provide a reason or explanation, [the outlet was founded
 by Chinese-Americans](https://www.theepochtimes.com/about-us) who fled
 communist China and now take a strong stance against the CCP (Chinese Communist

--- a/website/content/events/youtube-demonetizes-the-progressive-soapbox/index.md
+++ b/website/content/events/youtube-demonetizes-the-progressive-soapbox/index.md
@@ -10,7 +10,7 @@ extra:
  - [ 'twitter.com/theProgSoapbox/status/1357098310532820995', 'archive.is/YRkWV' ]
 ---
 
-[YouTube](/youtube/) demonetized _The Progressive Soapbox_, a progressive
+YouTube demonetized _The Progressive Soapbox_, a progressive
 political commentary channel, without providing specific examples of guidelines
 violations.
 

--- a/website/content/events/youtube-demonetizes-we-are-change/index.md
+++ b/website/content/events/youtube-demonetizes-we-are-change/index.md
@@ -11,7 +11,7 @@ sources:
  - [ 'BitChute "BREAKING: YouTube Just Directly Attacked This Channel" by We Are Change (7 Apr 2020)', 'www.bitchute.com/video/F-QOb-lvSx8/' ]
 ---
 
-[YouTube](/youtube/) demonetized _We Are Change_, the independent media outlet
+YouTube demonetized _We Are Change_, the independent media outlet
 lead by Luke Rudkowski. The channel had **no active strikes** and was **not
 given an explanation**.
 

--- a/website/content/events/youtube-efforts-on-inclusion/index.md
+++ b/website/content/events/youtube-efforts-on-inclusion/index.md
@@ -8,7 +8,7 @@ sources:
  - [ 'YouTube Official Blog "Updates on our efforts to make YouTube a more inclusive platform" by Johanna Wright (3 Dec 2020)', 'archive.is/adrP5' ]
 ---
 
-[YouTube](/youtube/) published a blog post talking about all the creepy steps
+YouTube published a blog post talking about all the creepy steps
 they will start taking in order to be more "inclusive." For example, the
 article [detailed](https://archive.is/adrP5#selection-1423.0-1423.580) how
 YouTube would be asking creators to, on "a voluntary basis", provide personal

--- a/website/content/events/youtube-purges-harmful-conpsiracy-channels/index.md
+++ b/website/content/events/youtube-purges-harmful-conpsiracy-channels/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'twitter.com/LBRYcom/status/1316750633500893186', 'archive.is/QVoA7' ]
 ---
 
-In a blog post, [YouTube](/youtube/) bragged about how many conspiracy channels
+In a blog post, YouTube bragged about how many conspiracy channels
 and videos had been removed up until this point, and then
 [announced](https://archive.is/XAtuq#selection-1163.0-1171.307) the further
 purge of channels they deemed to be spreading "harmful conspiracy theories":

--- a/website/content/events/youtube-removes-another-liberty-report-for-medical-misinfo/index.md
+++ b/website/content/events/youtube-removes-another-liberty-report-for-medical-misinfo/index.md
@@ -8,7 +8,7 @@ sources:
  - [ 'twitter.com/RonPaul/status/1341385036961116160', 'archive.is/nR1BI' ]
 ---
 
-[YouTube](/youtube/) removed yet another episode of the _Ron Paul Liberty
+YouTube removed yet another episode of the _Ron Paul Liberty
 Report_ [due to "medical misinformation."](removal-screenshot.jpg) The video had been published for
 nearly two months. It was removed about three months after [YouTube removed a
 different

--- a/website/content/events/youtube-removes-another-tlav-covid-video/index.md
+++ b/website/content/events/youtube-removes-another-tlav-covid-video/index.md
@@ -9,7 +9,7 @@ sources:
  - [ 'twitter.com/TLAVagabond/status/1336573253054238721', 'archive.is/ooNND' ]
 ---
 
-[YouTube](/youtube/) removed a video from _The Last American Vagabond's_ backup
+YouTube removed a video from _The Last American Vagabond's_ backup
 channel titled "_FDA Admits 2 People Died In Pfizer Trials, Vaccines And
 Nanoparticles & Debunking Another Mask Study_", [claiming it
 violated](notice.jpg) YouTube's "medical misinformation policy."

--- a/website/content/events/youtube-removes-another-tlav-vaccine-video/index.md
+++ b/website/content/events/youtube-removes-another-tlav-vaccine-video/index.md
@@ -10,7 +10,7 @@ sources:
  - [ 'The Last American Vagabond "The Alarmingly Blind Trust In Vaccines/Health Authorities, Understanding MRNA & Jail For No Mask" on BitChute (18 Dec 2020)', 'www.bitchute.com/video/boJGumYk80hm/' ]
 ---
 
-[YouTube](/youtube/) removed yet another video by _The Last American Vagabond_
+YouTube removed yet another video by _The Last American Vagabond_
 regarding COVID and trust in the vaccine. This one was titled "The Alarmingly
 Blind Trust In Vaccines/Health Authorities, Understanding MRNA & Jail For No
 Mask", and it can still be viewed [on

--- a/website/content/events/youtube-removes-scott-adams-ep1213/index.md
+++ b/website/content/events/youtube-removes-scott-adams-ep1213/index.md
@@ -11,7 +11,7 @@ extra:
  - [ '', 'socialblade.com/youtube/channel/UCfpnY5NnBl-8L7SvICuYkYQ' ]
 ---
 
-[YouTube](/youtube/) removed _Episode 1213 Scott Adams: Biden COVID Plan,
+YouTube removed _Episode 1213 Scott Adams: Biden COVID Plan,
 Swalwell's Chinese Spy, Pelosi Still a Steaming Pile_. The video was removed
 [for violating](notice.jpg) YouTube's "spam, deceptive practices and scam
 policy."

--- a/website/content/events/youtube-removes-timcast-irl-alex-jones-michael-malice-episode/index.md
+++ b/website/content/events/youtube-removes-timcast-irl-alex-jones-michael-malice-episode/index.md
@@ -14,7 +14,7 @@ sources:
  - [ 'Reclaim The Net "YouTube removes Alex Jones Tim Pool podcast for “harassment and bullying”" by Tom Parker (13 Nov 2020)', 'reclaimthenet.org/youtube-removes-alex-jones-tim-pool-podcast-episode/' ]
 ---
 
-[YouTube](/youtube/) removed a nearly four hour-long episode of the _Timcast
+YouTube removed a nearly four hour-long episode of the _Timcast
 IRL_ podcast that featured Alex Jones and Michael Malice. YouTube
 misinterpreted a single comment made by Jones that they claimed was a Community
 Guidelines violation.

--- a/website/content/events/youtube-removes-tom-woods-covid-cult-video/index.md
+++ b/website/content/events/youtube-removes-tom-woods-covid-cult-video/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'Mises Institute "YouTube Attempts to Silence the Mises Institute" by Jeff Deist (25 Nov 2020)', 'mises.org/power-market/youtube-attempts-silence-mises-institute' ]
 ---
 
-[YouTube](/youtube/) removed a video from [_The Mises
+YouTube removed a video from [_The Mises
 Institute_](https://mises.org/), a non-profit that promotes Austrian economics
 and freedom. The video, titled _The Covid Cult | Thomas E. Woods, Jr._,
 accumulated **1.5 million views** before YouTube [removed it](notice.jpg)

--- a/website/content/events/youtube-removes-videos-of-doctors-testifying-in-senate-hearing/index.md
+++ b/website/content/events/youtube-removes-videos-of-doctors-testifying-in-senate-hearing/index.md
@@ -13,7 +13,7 @@ sources:
  - [ 'Reclaim The Net "YouTube deletes videos of doctors testifying in Senate Homeland Committee as “coronavirus misinformation”" by Christina Maas  (29 Jan 2021)', 'reclaimthenet.org/youtube-deletes-videos-of-doctors-testifying-in-senate-homeland-committee/' ]
 ---
 
-[YouTube](/youtube/) removed two videos from Senator Ron Johnson's channel for
+YouTube removed two videos from Senator Ron Johnson's channel for
 violating [YouTube's COVID-19
 policies](/e/youtube-says-contradicting-who-will-violate-guidelines/). The
 videos were of doctors testifying at a US Senate hearing about different

--- a/website/content/events/youtube-suspends-demonetizes-oann/index.md
+++ b/website/content/events/youtube-suspends-demonetizes-oann/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'zerohedge.com/political/youtube-suspends-pro-trump-news-network-oann-completely-demonetizes-channel-over-covid-19', 'archive.is/Krbp5' ]
 ---
 
-[YouTube](/youtube/) demonetized _One America News_, a right wing media outlet,
+YouTube demonetized _One America News_, a right wing media outlet,
 and gave them a one week suspension shortly after activists from several
 corporate media organizations published articles
 ([CNN](https://archive.is/7yBhT), [CNBC](https://archive.is/SC9Vb),

--- a/website/content/events/youtube-tests-hidden-dislike-counts/index.md
+++ b/website/content/events/youtube-tests-hidden-dislike-counts/index.md
@@ -14,7 +14,7 @@ extra:
  - [ 'Breitbart "Bokhari: YouTube’s Plan to Stop Users Expressing Disapproval of Elites" by Allum Bokhari (3 Apr 2021)', 'archive.ph/GgSMA' ]
 ---
 
-[YouTube](/youtube/) started rolling out hidden dislikes to a small group of
+YouTube started rolling out hidden dislikes to a small group of
 creators for testing:
 
 > In response to creator feedback around well-being and targeted dislike

--- a/website/content/events/youtube-will-remove-content-critical-of-election/index.md
+++ b/website/content/events/youtube-will-remove-content-critical-of-election/index.md
@@ -13,7 +13,7 @@ extra:
  - [ 'twitter.com/JackPosobiec/status/1336687212226867206', 'archive.is/7WaWn' ]
 ---
 
-[YouTube](/youtube/) announced via a blog post that they would be removing
+YouTube announced via a blog post that they would be removing
 content that alleges "that widespread fraud or errors changed the outcome of
 the 2020 U.S. Presidential election." An excerpt from the blog post
 [reads](https://archive.is/LppDR#selection-1203.0-1203.450):


### PR DESCRIPTION
The new UI of having the simple tags at the top of the event pages makes the corpo links within the articles themselves redundant.